### PR TITLE
[FEAT] 17 상품관 상품 목록 조회 API 추가

### DIFF
--- a/src/main/java/com/shinhan/esg_be/domain/social/controller/EcoProductController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/controller/EcoProductController.java
@@ -1,0 +1,22 @@
+package com.shinhan.esg_be.domain.social.controller;
+
+import com.shinhan.esg_be.domain.social.dto.response.EcoProductResponse;
+import com.shinhan.esg_be.domain.social.service.EcoProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/esg/s")
+@RequiredArgsConstructor
+public class EcoProductController {
+
+    private final EcoProductService ecoProductService;
+
+    @GetMapping("/products")
+    public ResponseEntity<EcoProductResponse> getProducts() {
+        return ResponseEntity.ok(ecoProductService.getProducts());
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/dto/response/EcoProductItemResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/dto/response/EcoProductItemResponse.java
@@ -1,0 +1,35 @@
+package com.shinhan.esg_be.domain.social.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class EcoProductItemResponse {
+
+    private final Long productId;
+    private final String name;
+    private final String category;
+    private final Long price;
+    private final String imageUrl;
+    private final String description;
+    private final Integer stock;
+    private final Boolean soldOut;
+
+    public EcoProductItemResponse(
+            Long productId,
+            String name,
+            String category,
+            Long price,
+            String imageUrl,
+            String description,
+            Integer stock
+    ) {
+        this.productId = productId;
+        this.name = name;
+        this.category = category;
+        this.price = price;
+        this.imageUrl = imageUrl;
+        this.description = description;
+        this.stock = stock;
+        this.soldOut = stock == null || stock <= 0;
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/dto/response/EcoProductResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/dto/response/EcoProductResponse.java
@@ -1,0 +1,13 @@
+package com.shinhan.esg_be.domain.social.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class EcoProductResponse {
+
+    private final List<EcoProductItemResponse> products;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/repository/EcoProductRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/repository/EcoProductRepository.java
@@ -1,0 +1,27 @@
+package com.shinhan.esg_be.domain.social.repository;
+
+import com.shinhan.esg_be.domain.social.dto.response.EcoProductItemResponse;
+import com.shinhan.esg_be.domain.social.entity.EcoProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface EcoProductRepository extends JpaRepository<EcoProduct, Long> {
+
+    @Query("""
+            select new com.shinhan.esg_be.domain.social.dto.response.EcoProductItemResponse(
+                e.productId,
+                e.name,
+                e.category,
+                e.price,
+                e.imageUrl,
+                e.description,
+                e.stock
+            )
+            from EcoProduct e
+            where e.isActive = true
+            order by e.productId desc
+            """)
+    List<EcoProductItemResponse> findActiveProducts();
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/service/EcoProductService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/service/EcoProductService.java
@@ -1,0 +1,19 @@
+package com.shinhan.esg_be.domain.social.service;
+
+import com.shinhan.esg_be.domain.social.dto.response.EcoProductResponse;
+import com.shinhan.esg_be.domain.social.repository.EcoProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EcoProductService {
+
+    private final EcoProductRepository ecoProductRepository;
+
+    public EcoProductResponse getProducts() {
+        return new EcoProductResponse(ecoProductRepository.findActiveProducts());
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #17 

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- 가치가게 상품 목록 조회 API를 추가했습니다.
- 활성 상품만 조회하도록 하고, 프론트에서 바로 품절 표시가 가능하도록 재고와 품절 여부를 함께 응답하도록 구성했습니다.

## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->

## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [x] 로컬에서 정상 동작 확인
- [ ] API 테스트 완료 (해당되면)
- [ ] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
