### PR TITLE
[FEAT] 21 상품 상세보기 기능 api 구현

### DIFF
--- a/src/main/java/com/shinhan/esg_be/domain/social/controller/EcoProductController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/controller/EcoProductController.java
@@ -1,10 +1,12 @@
 package com.shinhan.esg_be.domain.social.controller;
 
+import com.shinhan.esg_be.domain.social.dto.response.EcoProductDetailResponse;
 import com.shinhan.esg_be.domain.social.dto.response.EcoProductResponse;
 import com.shinhan.esg_be.domain.social.service.EcoProductService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -18,5 +20,10 @@ public class EcoProductController {
     @GetMapping("/products")
     public ResponseEntity<EcoProductResponse> getProducts() {
         return ResponseEntity.ok(ecoProductService.getProducts());
+    }
+
+    @GetMapping("/products/{productId}")
+    public ResponseEntity<EcoProductDetailResponse> getProduct(@PathVariable Long productId) {
+        return ResponseEntity.ok(ecoProductService.getProduct(productId));
     }
 }

--- a/src/main/java/com/shinhan/esg_be/domain/social/dto/response/EcoProductDetailResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/dto/response/EcoProductDetailResponse.java
@@ -1,0 +1,35 @@
+package com.shinhan.esg_be.domain.social.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class EcoProductDetailResponse {
+
+    private final Long productId;
+    private final String name;
+    private final String category;
+    private final Long price;
+    private final String imageUrl;
+    private final String description;
+    private final Integer stock;
+    private final Boolean soldOut;
+
+    public EcoProductDetailResponse(
+            Long productId,
+            String name,
+            String category,
+            Long price,
+            String imageUrl,
+            String description,
+            Integer stock
+    ) {
+        this.productId = productId;
+        this.name = name;
+        this.category = category;
+        this.price = price;
+        this.imageUrl = imageUrl;
+        this.description = description;
+        this.stock = stock;
+        this.soldOut = stock == null || stock <= 0;
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/repository/EcoProductRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/repository/EcoProductRepository.java
@@ -1,11 +1,14 @@
 package com.shinhan.esg_be.domain.social.repository;
 
+import com.shinhan.esg_be.domain.social.dto.response.EcoProductDetailResponse;
 import com.shinhan.esg_be.domain.social.dto.response.EcoProductItemResponse;
 import com.shinhan.esg_be.domain.social.entity.EcoProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 
 public interface EcoProductRepository extends JpaRepository<EcoProduct, Long> {
 
@@ -24,4 +27,20 @@ public interface EcoProductRepository extends JpaRepository<EcoProduct, Long> {
             order by e.productId desc
             """)
     List<EcoProductItemResponse> findActiveProducts();
+
+    @Query("""
+            select new com.shinhan.esg_be.domain.social.dto.response.EcoProductDetailResponse(
+                e.productId,
+                e.name,
+                e.category,
+                e.price,
+                e.imageUrl,
+                e.description,
+                e.stock
+            )
+            from EcoProduct e
+            where e.productId = :productId
+              and e.isActive = true
+            """)
+    Optional<EcoProductDetailResponse> findActiveProductDetail(@Param("productId") Long productId);
 }

--- a/src/main/java/com/shinhan/esg_be/domain/social/service/EcoProductService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/service/EcoProductService.java
@@ -1,10 +1,14 @@
 package com.shinhan.esg_be.domain.social.service;
 
+import com.shinhan.esg_be.domain.social.dto.response.EcoProductDetailResponse;
 import com.shinhan.esg_be.domain.social.dto.response.EcoProductResponse;
 import com.shinhan.esg_be.domain.social.repository.EcoProductRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
 
 @Service
 @RequiredArgsConstructor
@@ -15,5 +19,10 @@ public class EcoProductService {
 
     public EcoProductResponse getProducts() {
         return new EcoProductResponse(ecoProductRepository.findActiveProducts());
+    }
+
+    public EcoProductDetailResponse getProduct(Long productId) {
+        return ecoProductRepository.findActiveProductDetail(productId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "상품을 찾을 수 없습니다."));
     }
 }


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- 가치가게 상품 상세 조회 API를 추가했습니다.
- 상품 목록에서 선택한 productId를 기반으로 상세페이지에서 필요한 상품 데이터를 조회할 수 있도록 구현했습니다.

## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->
- EcoProductController에 GET /api/v1/esg/s/products/{productId} 엔드포인트를 추가했습니다.
- EcoProductService, EcoProductRepository에 상품 단건 조회 로직을 구현했습니다.
- EcoProductDetailResponse DTO를 추가해 상품 상세 정보, 재고, 품절 여부를 응답하도록 구성했습니다.

## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [x] 로컬에서 정상 동작 확인
- [x] API 테스트 완료 (해당되면)
- [x] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
