### PR TITLE
feat: 적금 가입 API 추가

### DIFF
--- a/src/main/java/com/shinhan/esg_be/domain/bank/controller/SavingController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/controller/SavingController.java
@@ -1,0 +1,30 @@
+package com.shinhan.esg_be.domain.bank.controller;
+
+import com.shinhan.esg_be.domain.bank.dto.request.SavingApplyRequest;
+import com.shinhan.esg_be.domain.bank.dto.response.SavingApplyResponse;
+import com.shinhan.esg_be.domain.bank.service.SavingService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/finance/savings")
+@RequiredArgsConstructor
+public class SavingController {
+
+    private final SavingService savingService;
+
+    @PostMapping("/apply")
+    public ResponseEntity<SavingApplyResponse> applySaving(
+            @AuthenticationPrincipal String loginId,
+            @Valid @RequestBody SavingApplyRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(savingService.applySaving(loginId, request));
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/bank/dto/request/SavingApplyRequest.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/dto/request/SavingApplyRequest.java
@@ -1,0 +1,9 @@
+package com.shinhan.esg_be.domain.bank.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record SavingApplyRequest(
+        @NotNull(message = "적금 상품 ID는 필수입니다.")
+        Long productId
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/bank/dto/response/SavingApplyResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/dto/response/SavingApplyResponse.java
@@ -1,0 +1,6 @@
+package com.shinhan.esg_be.domain.bank.dto.response;
+
+public record SavingApplyResponse(
+        String status
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/bank/entity/UserSaving.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/entity/UserSaving.java
@@ -67,4 +67,22 @@ public class UserSaving {
     @LastModifiedDate
     @Column(name = "updated_at", nullable = false)
     private LocalDateTime updatedAt;
+
+    public static UserSaving create(
+            User user,
+            FinancialProduct financialProduct,
+            Long monthlyAmount,
+            LocalDate maturityDate,
+            Integer score
+    ) {
+        UserSaving userSaving = new UserSaving();
+        userSaving.user = user;
+        userSaving.financialProduct = financialProduct;
+        userSaving.monthlyAmount = monthlyAmount;
+        userSaving.maturityDate = maturityDate;
+        userSaving.status = SavingStatus.ACTIVE;
+        userSaving.hasPenalty = false;
+        userSaving.score = score;
+        return userSaving;
+    }
 }

--- a/src/main/java/com/shinhan/esg_be/domain/bank/service/SavingService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/service/SavingService.java
@@ -1,0 +1,55 @@
+package com.shinhan.esg_be.domain.bank.service;
+
+import com.shinhan.esg_be.domain.bank.dto.request.SavingApplyRequest;
+import com.shinhan.esg_be.domain.bank.dto.response.SavingApplyResponse;
+import com.shinhan.esg_be.domain.bank.entity.FinancialProduct;
+import com.shinhan.esg_be.domain.bank.entity.UserSaving;
+import com.shinhan.esg_be.domain.bank.entity.enums.ProductType;
+import com.shinhan.esg_be.domain.bank.repository.FinancialProductRepository;
+import com.shinhan.esg_be.domain.bank.repository.UserSavingRepository;
+import com.shinhan.esg_be.domain.user.entity.User;
+import com.shinhan.esg_be.domain.user.repository.UserRepository;
+import com.shinhan.esg_be.global.exception.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class SavingService {
+
+    private static final long DEFAULT_MONTHLY_AMOUNT = 300_000L;
+
+    private final UserRepository userRepository;
+    private final FinancialProductRepository financialProductRepository;
+    private final UserSavingRepository userSavingRepository;
+
+    public SavingApplyResponse applySaving(String loginId, SavingApplyRequest request) {
+        User user = userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new BadRequestException("사용자를 찾을 수 없습니다."));
+
+        FinancialProduct product = financialProductRepository.findByFinProductIdAndTypeAndIsActiveTrue(
+                        request.productId(),
+                        ProductType.SAVINGS
+                )
+                .orElseThrow(() -> new BadRequestException("적금 상품을 찾을 수 없습니다."));
+
+        Long monthlyAmount = product.getMonthlyPaymentAmount() != null
+                ? product.getMonthlyPaymentAmount()
+                : DEFAULT_MONTHLY_AMOUNT;
+
+        UserSaving userSaving = UserSaving.create(
+                user,
+                product,
+                monthlyAmount,
+                LocalDate.now().plusMonths(product.getDurationMonths()),
+                user.getTotalScore()
+        );
+
+        userSavingRepository.save(userSaving);
+        return new SavingApplyResponse(userSaving.getStatus().name());
+    }
+}

--- a/src/test/java/com/shinhan/esg_be/domain/bank/controller/SavingControllerTest.java
+++ b/src/test/java/com/shinhan/esg_be/domain/bank/controller/SavingControllerTest.java
@@ -1,0 +1,59 @@
+package com.shinhan.esg_be.domain.bank.controller;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shinhan.esg_be.domain.bank.dto.request.SavingApplyRequest;
+import com.shinhan.esg_be.domain.bank.dto.response.SavingApplyResponse;
+import com.shinhan.esg_be.domain.bank.service.SavingService;
+import com.shinhan.esg_be.global.exception.GlobalExceptionHandler;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.BDDMockito.given;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@ExtendWith(MockitoExtension.class)
+class SavingControllerTest {
+
+    private MockMvc mockMvc;
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @InjectMocks
+    private SavingController savingController;
+
+    @Mock
+    private SavingService savingService;
+
+    @BeforeEach
+    void setUp() {
+        mockMvc = MockMvcBuilders.standaloneSetup(savingController)
+                .setControllerAdvice(new GlobalExceptionHandler())
+                .build();
+    }
+
+    @Test
+    @DisplayName("적금 가입 API는 생성 상태를 반환한다")
+    void applySaving() throws Exception {
+        SavingApplyRequest request = new SavingApplyRequest(2L);
+        given(savingService.applySaving(isNull(), any(SavingApplyRequest.class)))
+                .willReturn(new SavingApplyResponse("ACTIVE"));
+
+        mockMvc.perform(post("/api/v1/finance/savings/apply")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.status").value("ACTIVE"));
+    }
+}

--- a/src/test/java/com/shinhan/esg_be/domain/bank/service/SavingServiceTest.java
+++ b/src/test/java/com/shinhan/esg_be/domain/bank/service/SavingServiceTest.java
@@ -1,0 +1,116 @@
+package com.shinhan.esg_be.domain.bank.service;
+
+import com.shinhan.esg_be.domain.bank.dto.request.SavingApplyRequest;
+import com.shinhan.esg_be.domain.bank.dto.response.SavingApplyResponse;
+import com.shinhan.esg_be.domain.bank.entity.FinancialProduct;
+import com.shinhan.esg_be.domain.bank.entity.UserSaving;
+import com.shinhan.esg_be.domain.bank.entity.enums.ProductType;
+import com.shinhan.esg_be.domain.bank.repository.FinancialProductRepository;
+import com.shinhan.esg_be.domain.bank.repository.UserSavingRepository;
+import com.shinhan.esg_be.domain.user.entity.User;
+import com.shinhan.esg_be.domain.user.repository.UserRepository;
+import com.shinhan.esg_be.global.exception.BadRequestException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.lang.reflect.Constructor;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+@ExtendWith(MockitoExtension.class)
+class SavingServiceTest {
+
+    @InjectMocks
+    private SavingService savingService;
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Mock
+    private FinancialProductRepository financialProductRepository;
+
+    @Mock
+    private UserSavingRepository userSavingRepository;
+
+    @Test
+    @DisplayName("적금 가입 시 원장을 생성하고 ACTIVE 상태를 반환한다")
+    void applySaving() {
+        User user = createUser("saving-user-1", 100, 400, 200, 100);
+        FinancialProduct product = createSavingProduct(2L, "그린 스텝업 적금", 300_000L, 12);
+
+        given(userRepository.findByLoginId(user.getLoginId())).willReturn(Optional.of(user));
+        given(financialProductRepository.findByFinProductIdAndTypeAndIsActiveTrue(2L, ProductType.SAVINGS))
+                .willReturn(Optional.of(product));
+
+        SavingApplyResponse response = savingService.applySaving(user.getLoginId(), new SavingApplyRequest(2L));
+
+        ArgumentCaptor<UserSaving> captor = ArgumentCaptor.forClass(UserSaving.class);
+        verify(userSavingRepository).save(captor.capture());
+        UserSaving saved = captor.getValue();
+
+        assertThat(response.status()).isEqualTo("ACTIVE");
+        assertThat(saved.getMonthlyAmount()).isEqualTo(300_000L);
+        assertThat(saved.getScore()).isEqualTo(800);
+        assertThat(saved.getMaturityDate()).isEqualTo(LocalDate.now().plusMonths(12));
+    }
+
+    @Test
+    @DisplayName("적금 상품이 아니면 가입을 거절한다")
+    void rejectWhenSavingProductNotFound() {
+        User user = createUser("saving-user-2", 50, 250, 100, 100);
+
+        given(userRepository.findByLoginId(user.getLoginId())).willReturn(Optional.of(user));
+        given(financialProductRepository.findByFinProductIdAndTypeAndIsActiveTrue(99L, ProductType.SAVINGS))
+                .willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> savingService.applySaving(user.getLoginId(), new SavingApplyRequest(99L)))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("적금 상품을 찾을 수 없습니다.");
+    }
+
+    private User createUser(String loginId, int eScore, int sScore, int gActivityScore, int gRepaymentScore) {
+        User user = newInstance(User.class);
+        ReflectionTestUtils.setField(user, "loginId", loginId);
+        ReflectionTestUtils.setField(user, "eScore", eScore);
+        ReflectionTestUtils.setField(user, "sScore", sScore);
+        ReflectionTestUtils.setField(user, "gActivityScore", gActivityScore);
+        ReflectionTestUtils.setField(user, "gRepaymentScore", gRepaymentScore);
+        ReflectionTestUtils.setField(user, "abuseCount", 0);
+        return user;
+    }
+
+    private FinancialProduct createSavingProduct(Long id, String name, Long monthlyPaymentAmount, int durationMonths) {
+        FinancialProduct product = newInstance(FinancialProduct.class);
+        ReflectionTestUtils.setField(product, "finProductId", id);
+        ReflectionTestUtils.setField(product, "name", name);
+        ReflectionTestUtils.setField(product, "type", ProductType.SAVINGS);
+        ReflectionTestUtils.setField(product, "baseRate", new BigDecimal("2.00"));
+        ReflectionTestUtils.setField(product, "maxRate", new BigDecimal("4.40"));
+        ReflectionTestUtils.setField(product, "isActive", true);
+        ReflectionTestUtils.setField(product, "durationMonths", durationMonths);
+        ReflectionTestUtils.setField(product, "monthlyPaymentAmount", monthlyPaymentAmount);
+        return product;
+    }
+
+    private <T> T newInstance(Class<T> type) {
+        try {
+            Constructor<T> constructor = type.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
+        } catch (Exception exception) {
+            throw new IllegalStateException("Failed to instantiate " + type.getSimpleName(), exception);
+        }
+    }
+}


### PR DESCRIPTION

## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #35

## 📌 작업 내용
- FIN-03 적금 가입 API를 구현했습니다.
- 사용자/상품 검증 후 적금 원장을 생성하도록 서비스 로직을 추가했습니다.
- 적금 가입 관련 서비스/컨트롤러 테스트를 추가했습니다.

## 🛠 변경 사항
- `POST /api/v1/finance/savings/apply` 엔드포인트 추가
- `SavingApplyRequest`, `SavingApplyResponse` DTO 추가
- `SavingService` 추가
  - 사용자 조회
  - 활성 적금 상품 조회
  - `UserSaving` 생성 및 저장
  - 가입 시점 점수(`score`) 저장
  - 월 납입금(`monthlyPaymentAmount`) 반영
  - 만기일(`today + durationMonths`) 계산
- `UserSaving` 엔티티에 `create(...)` 정적 생성 메서드 추가
- 테스트 추가
  - `SavingServiceTest`
  - `SavingControllerTest`

## ✅ 테스트 결과
- [x] 로컬에서 정상 동작 확인
- [x] API 테스트 완료 (해당되면)
- [x] 빌드 에러 없음