### PR TITLE
[FEAT] 31 포트원 결제 api 및 결제 기능 추가

### DIFF
--- a/src/main/java/com/shinhan/esg_be/domain/social/controller/PaymentController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/controller/PaymentController.java
@@ -1,8 +1,11 @@
 package com.shinhan.esg_be.domain.social.controller;
 
 import com.shinhan.esg_be.domain.social.dto.request.PaymentPrepareRequest;
+import com.shinhan.esg_be.domain.social.dto.request.PaymentVerifyRequest;
 import com.shinhan.esg_be.domain.social.dto.response.PaymentPrepareResponse;
+import com.shinhan.esg_be.domain.social.dto.response.PaymentVerifyResponse;
 import com.shinhan.esg_be.domain.social.service.PaymentPrepareService;
+import com.shinhan.esg_be.domain.social.service.PaymentVerifyService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -18,9 +21,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class PaymentController {
 
     private final PaymentPrepareService paymentPrepareService;
+    private final PaymentVerifyService paymentVerifyService;
 
     @PostMapping("/prepare")
     public ResponseEntity<PaymentPrepareResponse> preparePayment(@RequestBody @Valid PaymentPrepareRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(paymentPrepareService.preparePayment(request));
+    }
+
+    @PostMapping("/verify")
+    public ResponseEntity<PaymentVerifyResponse> verifyPayment(@RequestBody @Valid PaymentVerifyRequest request) {
+        return ResponseEntity.ok(paymentVerifyService.verifyDonationPayment(request));
     }
 }

--- a/src/main/java/com/shinhan/esg_be/domain/social/controller/PaymentController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/controller/PaymentController.java
@@ -1,0 +1,26 @@
+package com.shinhan.esg_be.domain.social.controller;
+
+import com.shinhan.esg_be.domain.social.dto.request.PaymentPrepareRequest;
+import com.shinhan.esg_be.domain.social.dto.response.PaymentPrepareResponse;
+import com.shinhan.esg_be.domain.social.service.PaymentPrepareService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/payments")
+@RequiredArgsConstructor
+public class PaymentController {
+
+    private final PaymentPrepareService paymentPrepareService;
+
+    @PostMapping("/prepare")
+    public ResponseEntity<PaymentPrepareResponse> preparePayment(@RequestBody @Valid PaymentPrepareRequest request) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(paymentPrepareService.preparePayment(request));
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/dto/request/PaymentPrepareRequest.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/dto/request/PaymentPrepareRequest.java
@@ -1,0 +1,18 @@
+package com.shinhan.esg_be.domain.social.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PaymentPrepareRequest {
+
+    @NotNull
+    private Long donationId;
+
+    @NotNull
+    @Min(30000)
+    private Long amount;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/dto/request/PaymentVerifyRequest.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/dto/request/PaymentVerifyRequest.java
@@ -1,0 +1,20 @@
+package com.shinhan.esg_be.domain.social.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class PaymentVerifyRequest {
+
+    @NotNull
+    private Long donationId;
+
+    @NotBlank
+    private String impUid;
+
+    @NotBlank
+    private String merchantUid;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/dto/response/PaymentPrepareResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/dto/response/PaymentPrepareResponse.java
@@ -1,0 +1,14 @@
+package com.shinhan.esg_be.domain.social.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PaymentPrepareResponse {
+
+    private final String merchantUid;
+    private final Long donationId;
+    private final String donationName;
+    private final Long amount;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/dto/response/PaymentVerifyResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/dto/response/PaymentVerifyResponse.java
@@ -1,0 +1,17 @@
+package com.shinhan.esg_be.domain.social.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class PaymentVerifyResponse {
+
+    private final Long paymentId;
+    private final Long donationId;
+    private final String donationName;
+    private final Long amount;
+    private final String paymentStatus;
+    private final Integer awardedPoint;
+    private final Integer currentPoint;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/entity/Payment.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/entity/Payment.java
@@ -7,6 +7,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,7 +15,13 @@ import lombok.NoArgsConstructor;
 import java.time.LocalDateTime;
 
 @Entity
-@Table(name = "payment")
+@Table(
+        name = "payment",
+        uniqueConstraints = {
+                @UniqueConstraint(name = "uk_payment_imp_uid", columnNames = "imp_uid"),
+                @UniqueConstraint(name = "uk_payment_merchant_id", columnNames = "merchant_id")
+        }
+)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class Payment extends BaseTimeEntity {

--- a/src/main/java/com/shinhan/esg_be/domain/social/entity/Payment.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/entity/Payment.java
@@ -68,4 +68,40 @@ public class Payment extends BaseTimeEntity {
 
     @Column(name = "receipt_url", nullable = false)
     private String receiptUrl;
+
+    public static Payment create(
+            String impUid,
+            String merchantId,
+            Long amount,
+            String paymentMethod,
+            String paymentStatus,
+            LocalDateTime paidAt,
+            String failedReason,
+            String buyerName,
+            String buyerEmail,
+            String buyerTel,
+            String pgProvider,
+            String pgTid,
+            String cardName,
+            String cardNumber,
+            String receiptUrl
+    ) {
+        Payment payment = new Payment();
+        payment.impUid = impUid;
+        payment.merchantId = merchantId;
+        payment.amount = amount;
+        payment.paymentMethod = paymentMethod;
+        payment.paymentStatus = paymentStatus;
+        payment.paidAt = paidAt;
+        payment.failedReason = failedReason;
+        payment.buyerName = buyerName;
+        payment.buyerEmail = buyerEmail;
+        payment.buyerTel = buyerTel;
+        payment.pgProvider = pgProvider;
+        payment.pgTid = pgTid;
+        payment.cardName = cardName;
+        payment.cardNumber = cardNumber;
+        payment.receiptUrl = receiptUrl;
+        return payment;
+    }
 }

--- a/src/main/java/com/shinhan/esg_be/domain/social/entity/UserDonation.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/entity/UserDonation.java
@@ -46,4 +46,12 @@ public class UserDonation {
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    public static UserDonation create(Payment payment, Donation donation, User user) {
+        UserDonation userDonation = new UserDonation();
+        userDonation.payment = payment;
+        userDonation.donation = donation;
+        userDonation.user = user;
+        return userDonation;
+    }
 }

--- a/src/main/java/com/shinhan/esg_be/domain/social/repository/DonationRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/repository/DonationRepository.java
@@ -70,4 +70,10 @@ public interface DonationRepository extends JpaRepository<Donation, Long> {
             @Param("donationId") Long donationId,
             @Param("baseDateTime") LocalDateTime baseDateTime
     );
+
+    Optional<Donation> findByDonationIdAndIsActiveTrueAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
+            Long donationId,
+            LocalDateTime startDate,
+            LocalDateTime endDate
+    );
 }

--- a/src/main/java/com/shinhan/esg_be/domain/social/repository/DonationRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/repository/DonationRepository.java
@@ -4,6 +4,7 @@ import com.shinhan.esg_be.domain.social.dto.response.DonationDetailResponse;
 import com.shinhan.esg_be.domain.social.dto.response.DonationItemResponse;
 import com.shinhan.esg_be.domain.social.entity.Donation;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -76,4 +77,12 @@ public interface DonationRepository extends JpaRepository<Donation, Long> {
             LocalDateTime startDate,
             LocalDateTime endDate
     );
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update Donation d
+            set d.currentAmount = d.currentAmount + :amount
+            where d.donationId = :donationId
+            """)
+    int increaseCurrentAmount(@Param("donationId") Long donationId, @Param("amount") Long amount);
 }

--- a/src/main/java/com/shinhan/esg_be/domain/social/repository/PaymentRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/repository/PaymentRepository.java
@@ -1,0 +1,11 @@
+package com.shinhan.esg_be.domain.social.repository;
+
+import com.shinhan.esg_be.domain.social.entity.Payment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PaymentRepository extends JpaRepository<Payment, Long> {
+
+    boolean existsByImpUid(String impUid);
+
+    boolean existsByMerchantId(String merchantId);
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/service/PaymentPrepareService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/service/PaymentPrepareService.java
@@ -10,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.UUID;
 
 import static org.springframework.http.HttpStatus.BAD_REQUEST;
@@ -26,12 +27,13 @@ public class PaymentPrepareService {
 
     public PaymentPrepareResponse preparePayment(PaymentPrepareRequest request) {
         validateAmount(request.getAmount());
+        LocalDateTime baseDateTime = LocalDate.now().atStartOfDay();
 
         Donation donation = donationRepository
                 .findByDonationIdAndIsActiveTrueAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
                         request.getDonationId(),
-                        LocalDate.now().atStartOfDay(),
-                        LocalDate.now().atStartOfDay()
+                        baseDateTime,
+                        baseDateTime
                 )
                 .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "기부 캠페인을 찾을 수 없습니다."));
 

--- a/src/main/java/com/shinhan/esg_be/domain/social/service/PaymentPrepareService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/service/PaymentPrepareService.java
@@ -1,0 +1,55 @@
+package com.shinhan.esg_be.domain.social.service;
+
+import com.shinhan.esg_be.domain.social.dto.request.PaymentPrepareRequest;
+import com.shinhan.esg_be.domain.social.dto.response.PaymentPrepareResponse;
+import com.shinhan.esg_be.domain.social.entity.Donation;
+import com.shinhan.esg_be.domain.social.repository.DonationRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.util.UUID;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PaymentPrepareService {
+
+    private static final long MIN_DONATION_AMOUNT = 30_000L;
+
+    private final DonationRepository donationRepository;
+
+    public PaymentPrepareResponse preparePayment(PaymentPrepareRequest request) {
+        validateAmount(request.getAmount());
+
+        Donation donation = donationRepository
+                .findByDonationIdAndIsActiveTrueAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
+                        request.getDonationId(),
+                        LocalDate.now().atStartOfDay(),
+                        LocalDate.now().atStartOfDay()
+                )
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "기부 캠페인을 찾을 수 없습니다."));
+
+        return new PaymentPrepareResponse(
+                createMerchantUid(),
+                donation.getDonationId(),
+                donation.getName(),
+                request.getAmount()
+        );
+    }
+
+    private void validateAmount(Long amount) {
+        if (amount == null || amount < MIN_DONATION_AMOUNT) {
+            throw new ResponseStatusException(BAD_REQUEST, "기부 금액은 30000원 이상이어야 합니다.");
+        }
+    }
+
+    private String createMerchantUid() {
+        return "DONATION-" + UUID.randomUUID();
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/service/PaymentVerifyService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/service/PaymentVerifyService.java
@@ -1,0 +1,119 @@
+package com.shinhan.esg_be.domain.social.service;
+
+import com.shinhan.esg_be.domain.point.service.result.ApplyActivityPointResult;
+import com.shinhan.esg_be.domain.reward.service.RewardService;
+import com.shinhan.esg_be.domain.reward.service.command.ApplyActivityRewardCommand;
+import com.shinhan.esg_be.domain.reward.service.result.ApplyActivityRewardResult;
+import com.shinhan.esg_be.domain.social.dto.request.PaymentVerifyRequest;
+import com.shinhan.esg_be.domain.social.dto.response.PaymentVerifyResponse;
+import com.shinhan.esg_be.domain.social.entity.Donation;
+import com.shinhan.esg_be.domain.social.entity.Payment;
+import com.shinhan.esg_be.domain.social.entity.UserDonation;
+import com.shinhan.esg_be.domain.social.repository.DonationRepository;
+import com.shinhan.esg_be.domain.social.repository.PaymentRepository;
+import com.shinhan.esg_be.domain.social.repository.UserDonationRepository;
+import com.shinhan.esg_be.domain.user.entity.User;
+import com.shinhan.esg_be.domain.user.repository.UserRepository;
+import com.shinhan.esg_be.global.common.enums.ActivityType;
+import com.shinhan.esg_be.global.exception.BadRequestException;
+import com.shinhan.esg_be.global.security.AuthContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class PaymentVerifyService {
+
+    private static final long MIN_DONATION_AMOUNT = 30_000L;
+
+    private final AuthContext authContext;
+    private final PortOnePaymentService portOnePaymentService;
+    private final DonationRepository donationRepository;
+    private final PaymentRepository paymentRepository;
+    private final UserDonationRepository userDonationRepository;
+    private final UserRepository userRepository;
+    private final RewardService rewardService;
+
+    public PaymentVerifyResponse verifyDonationPayment(PaymentVerifyRequest request) {
+        Long userId = authContext.currentUserId();
+        LocalDateTime activityDateTime = LocalDateTime.now();
+        LocalDateTime baseDateTime = activityDateTime.toLocalDate().atStartOfDay();
+
+        Donation donation = donationRepository
+                .findByDonationIdAndIsActiveTrueAndStartDateLessThanEqualAndEndDateGreaterThanEqual(
+                        request.getDonationId(),
+                        baseDateTime,
+                        baseDateTime
+                )
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "기부 캠페인을 찾을 수 없습니다."));
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        if (paymentRepository.existsByImpUid(request.getImpUid())) {
+            throw new BadRequestException("이미 처리된 결제입니다.");
+        }
+        if (paymentRepository.existsByMerchantId(request.getMerchantUid())) {
+            throw new BadRequestException("이미 사용된 merchantUid입니다.");
+        }
+
+        PortOnePaymentService.VerifiedPayment verifiedPayment =
+                portOnePaymentService.verify(request.getImpUid());
+
+        if (!request.getMerchantUid().equals(verifiedPayment.merchantUid())) {
+            throw new BadRequestException("merchantUid가 일치하지 않습니다.");
+        }
+        if (verifiedPayment.amount() < MIN_DONATION_AMOUNT) {
+            throw new BadRequestException("기부 금액은 30000원 이상이어야 합니다.");
+        }
+
+        Payment payment = paymentRepository.save(Payment.create(
+                verifiedPayment.impUid(),
+                verifiedPayment.merchantUid(),
+                verifiedPayment.amount(),
+                verifiedPayment.paymentMethod(),
+                verifiedPayment.paymentStatus(),
+                verifiedPayment.paidAt(),
+                verifiedPayment.failedReason(),
+                verifiedPayment.buyerName(),
+                verifiedPayment.buyerEmail(),
+                verifiedPayment.buyerTel(),
+                verifiedPayment.pgProvider(),
+                verifiedPayment.pgTid(),
+                verifiedPayment.cardName(),
+                verifiedPayment.cardNumber(),
+                verifiedPayment.receiptUrl()
+        ));
+
+        userDonationRepository.save(UserDonation.create(payment, donation, user));
+
+        ApplyActivityRewardResult rewardResult = rewardService.applyActivityReward(
+                new ApplyActivityRewardCommand(
+                        userId,
+                        ActivityType.DONATION,
+                        BigDecimal.valueOf(payment.getAmount()),
+                        activityDateTime
+                )
+        );
+
+        ApplyActivityPointResult pointResult = rewardResult.pointResult();
+
+        return new PaymentVerifyResponse(
+                payment.getPaymentId(),
+                donation.getDonationId(),
+                donation.getName(),
+                payment.getAmount(),
+                payment.getPaymentStatus(),
+                pointResult.activityPoint() + pointResult.bonusPoint(),
+                pointResult.pointAfter()
+        );
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/service/PaymentVerifyService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/service/PaymentVerifyService.java
@@ -93,6 +93,7 @@ public class PaymentVerifyService {
                 verifiedPayment.receiptUrl()
         ));
 
+        donationRepository.increaseCurrentAmount(donation.getDonationId(), payment.getAmount());
         userDonationRepository.save(UserDonation.create(payment, donation, user));
 
         ApplyActivityRewardResult rewardResult = rewardService.applyActivityReward(

--- a/src/main/java/com/shinhan/esg_be/domain/social/service/PortOnePaymentService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/service/PortOnePaymentService.java
@@ -1,0 +1,227 @@
+package com.shinhan.esg_be.domain.social.service;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shinhan.esg_be.global.config.PortOneProperties;
+import com.shinhan.esg_be.global.exception.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
+
+@Service
+@RequiredArgsConstructor
+public class PortOnePaymentService {
+
+    private static final int SUCCESS_CODE = 0;
+    private static final String PAID_STATUS = "paid";
+
+    private final ObjectMapper objectMapper;
+    private final PortOneProperties portOneProperties;
+
+    public VerifiedPayment verify(String impUid) {
+        validateCredentials();
+
+        HttpClient httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofMillis(portOneProperties.getApiConnectTimeout()))
+                .build();
+
+        String accessToken = getAccessToken(httpClient);
+
+        try {
+            HttpResponse<String> response = httpClient.send(
+                    buildPaymentLookupRequest(accessToken, "/payments/" + impUid),
+                    HttpResponse.BodyHandlers.ofString()
+            );
+            validateSuccessStatus(response.statusCode(), "PortOne 결제 조회에 실패했습니다.");
+            return extractVerifiedPayment(response.body(), impUid);
+        } catch (IOException e) {
+            throw new RuntimeException("PortOne 결제 응답 파싱에 실패했습니다.", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("PortOne 결제 조회 중 인터럽트가 발생했습니다.", e);
+        }
+    }
+
+    private HttpRequest buildPaymentLookupRequest(String accessToken, String path) {
+        return HttpRequest.newBuilder()
+                .uri(URI.create(portOneProperties.getApiBaseUrl() + path + "?include_sandbox=true"))
+                .header(HttpHeaders.AUTHORIZATION, accessToken)
+                .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .timeout(Duration.ofMillis(portOneProperties.getApiReadTimeout()))
+                .GET()
+                .build();
+    }
+
+    private VerifiedPayment extractVerifiedPayment(String responseBody, String impUid) throws IOException {
+        PaymentApiResponse apiResponse = objectMapper.readValue(responseBody, PaymentApiResponse.class);
+        if (apiResponse == null || apiResponse.code != SUCCESS_CODE || apiResponse.response == null) {
+            throw new BadRequestException("PortOne 결제 응답이 올바르지 않습니다.");
+        }
+
+        PaymentData payment = apiResponse.response;
+        if (!PAID_STATUS.equalsIgnoreCase(payment.status)) {
+            throw new BadRequestException("결제가 완료되지 않았습니다.");
+        }
+
+        return new VerifiedPayment(
+                payment.impUid,
+                payment.merchantUid,
+                payment.amount == null ? 0L : payment.amount.longValue(),
+                defaultText(payment.payMethod),
+                defaultText(payment.status),
+                toLocalDateTime(payment.paidAt),
+                payment.failReason,
+                defaultText(payment.buyerName),
+                defaultText(payment.buyerEmail),
+                defaultText(payment.buyerTel),
+                defaultText(payment.pgProvider),
+                defaultText(payment.pgTid),
+                defaultText(payment.cardName),
+                defaultText(payment.cardNumber),
+                defaultText(payment.receiptUrl)
+        );
+    }
+
+    private String getAccessToken(HttpClient httpClient) {
+        String body = String.format(
+                "{\"imp_key\":\"%s\",\"imp_secret\":\"%s\"}",
+                portOneProperties.getApiKey(),
+                portOneProperties.getApiSecret()
+        );
+
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(portOneProperties.getApiBaseUrl() + "/users/getToken"))
+                .header(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+                .header(HttpHeaders.ACCEPT, MediaType.APPLICATION_JSON_VALUE)
+                .timeout(Duration.ofMillis(portOneProperties.getApiReadTimeout()))
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+
+        try {
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            validateSuccessStatus(response.statusCode(), "PortOne 액세스 토큰 발급에 실패했습니다.");
+
+            TokenResponse tokenResponse = objectMapper.readValue(response.body(), TokenResponse.class);
+            if (tokenResponse == null || tokenResponse.code != SUCCESS_CODE || tokenResponse.response == null) {
+                throw new RuntimeException("PortOne 액세스 토큰 응답이 올바르지 않습니다.");
+            }
+            if (tokenResponse.response.accessToken == null || tokenResponse.response.accessToken.isBlank()) {
+                throw new RuntimeException("PortOne 액세스 토큰이 비어 있습니다.");
+            }
+            return tokenResponse.response.accessToken;
+        } catch (IOException e) {
+            throw new RuntimeException("PortOne 액세스 토큰 응답 파싱에 실패했습니다.", e);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("PortOne 액세스 토큰 발급 중 인터럽트가 발생했습니다.", e);
+        }
+    }
+
+    private void validateCredentials() {
+        if (portOneProperties.getApiKey() == null || portOneProperties.getApiKey().isBlank()) {
+            throw new RuntimeException("PortOne API key가 설정되지 않았습니다.");
+        }
+        if (portOneProperties.getApiSecret() == null || portOneProperties.getApiSecret().isBlank()) {
+            throw new RuntimeException("PortOne API secret이 설정되지 않았습니다.");
+        }
+    }
+
+    private void validateSuccessStatus(int statusCode, String message) {
+        if (statusCode < 200 || statusCode >= 300) {
+            throw new BadRequestException(message + " status=" + statusCode);
+        }
+    }
+
+    private LocalDateTime toLocalDateTime(Long epochSeconds) {
+        if (epochSeconds == null) {
+            return LocalDateTime.now();
+        }
+        return LocalDateTime.ofInstant(Instant.ofEpochSecond(epochSeconds), ZoneId.systemDefault());
+    }
+
+    private String defaultText(String value) {
+        return value == null ? "" : value;
+    }
+
+    public record VerifiedPayment(
+            String impUid,
+            String merchantUid,
+            Long amount,
+            String paymentMethod,
+            String paymentStatus,
+            LocalDateTime paidAt,
+            String failedReason,
+            String buyerName,
+            String buyerEmail,
+            String buyerTel,
+            String pgProvider,
+            String pgTid,
+            String cardName,
+            String cardNumber,
+            String receiptUrl
+    ) {
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class TokenResponse {
+        public int code;
+        public TokenData response;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class TokenData {
+        @JsonProperty("access_token")
+        public String accessToken;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class PaymentApiResponse {
+        public int code;
+        public PaymentData response;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    private static class PaymentData {
+        @JsonProperty("imp_uid")
+        public String impUid;
+        @JsonProperty("merchant_uid")
+        public String merchantUid;
+        public BigDecimal amount;
+        public String status;
+        @JsonProperty("pay_method")
+        public String payMethod;
+        @JsonProperty("paid_at")
+        public Long paidAt;
+        @JsonProperty("fail_reason")
+        public String failReason;
+        @JsonProperty("buyer_name")
+        public String buyerName;
+        @JsonProperty("buyer_email")
+        public String buyerEmail;
+        @JsonProperty("buyer_tel")
+        public String buyerTel;
+        @JsonProperty("pg_provider")
+        public String pgProvider;
+        @JsonProperty("pg_tid")
+        public String pgTid;
+        @JsonProperty("card_name")
+        public String cardName;
+        @JsonProperty("card_number")
+        public String cardNumber;
+        @JsonProperty("receipt_url")
+        public String receiptUrl;
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #31 

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- 기부 결제 준비 API와 결제 검증 API를 구현했습니다.
- 포트원 결제 검증 이후 결제 정보 저장, 기부 이력 저장, 포인트 보상 반영까지 연결했습니다.

## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->
- PaymentController, PaymentPrepareService, PaymentVerifyService를 추가해 /api/v1/payments/prepare, /api/v1/payments/verify 흐름을 구현했습니다.
- PaymentPrepareRequest/Response, PaymentVerifyRequest/Response DTO를 추가해 프론트 결제 연동 스펙을 정의했습니다.
- PortOnePaymentService를 추가해 포트원 토큰 발급 및 결제 조회 검증 로직을 구현했습니다.
- PaymentRepository 중복 검증 로직과 DonationRepository 결제 가능 캠페인 조회 로직을 추가했습니다.
- 결제 검증 성공 시 payment 저장, user_donation 저장, RewardService.applyActivityReward(...) 호출로 포인트 보상까지 반영되도록 구현했습니다.


## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [x] 로컬에서 정상 동작 확인
- [x] API 테스트 완료 (해당되면)
- [x] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
- 기부 결제는 prepare -> 포트원 결제 -> verify 흐름으로 구성되어 있습니다.
- verify 단계에서 포트원 결제 검증과 함께 결제 저장, 기부 이력 저장, 포인트 적립이 한 번에 처리되도록 구현했습니다.