### PR TITLE
36 feat 포인트샵 구매 기능 구현

### DIFF
--- a/src/main/java/com/shinhan/esg_be/domain/point/controller/PointShopItemController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/controller/PointShopItemController.java
@@ -1,0 +1,29 @@
+package com.shinhan.esg_be.domain.point.controller;
+
+import com.shinhan.esg_be.domain.point.dto.response.PointShopItemResponse;
+import com.shinhan.esg_be.domain.point.dto.response.PointShopItemsResponse;
+import com.shinhan.esg_be.domain.point.service.PointShopItemService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/point-shop")
+@RequiredArgsConstructor
+public class PointShopItemController {
+
+    private final PointShopItemService pointShopItemService;
+
+    @GetMapping("/items")
+    public ResponseEntity<PointShopItemsResponse> getItems() {
+        return ResponseEntity.ok(pointShopItemService.getItems());
+    }
+
+    @GetMapping("/items/{itemId}")
+    public ResponseEntity<PointShopItemResponse> getItem(@PathVariable Long itemId) {
+        return ResponseEntity.ok(pointShopItemService.getItem(itemId));
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/controller/PointShopPurchaseController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/controller/PointShopPurchaseController.java
@@ -1,0 +1,25 @@
+package com.shinhan.esg_be.domain.point.controller;
+
+import com.shinhan.esg_be.domain.point.dto.response.PointShopPurchaseResponse;
+import com.shinhan.esg_be.domain.point.service.PointShopPurchaseService;
+import com.shinhan.esg_be.global.security.AuthContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/point-shop")
+@RequiredArgsConstructor
+public class PointShopPurchaseController {
+
+    private final PointShopPurchaseService pointShopPurchaseService;
+    private final AuthContext authContext;
+
+    @PostMapping("/items/{itemId}/purchase")
+    public ResponseEntity<PointShopPurchaseResponse> purchase(@PathVariable Long itemId) {
+        return ResponseEntity.ok(pointShopPurchaseService.purchase(authContext.currentUserId(), itemId));
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/controller/PointShopPurchaseHistoryController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/controller/PointShopPurchaseHistoryController.java
@@ -1,0 +1,24 @@
+package com.shinhan.esg_be.domain.point.controller;
+
+import com.shinhan.esg_be.domain.point.dto.response.PointShopPurchaseHistoryResponse;
+import com.shinhan.esg_be.domain.point.service.PointShopPurchaseHistoryService;
+import com.shinhan.esg_be.global.security.AuthContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/point-shop")
+@RequiredArgsConstructor
+public class PointShopPurchaseHistoryController {
+
+    private final PointShopPurchaseHistoryService pointShopPurchaseHistoryService;
+    private final AuthContext authContext;
+
+    @GetMapping("/purchases")
+    public ResponseEntity<PointShopPurchaseHistoryResponse> getPurchases() {
+        return ResponseEntity.ok(pointShopPurchaseHistoryService.getPurchases(authContext.currentUserId()));
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/controller/PointShopSummaryController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/controller/PointShopSummaryController.java
@@ -1,0 +1,24 @@
+package com.shinhan.esg_be.domain.point.controller;
+
+import com.shinhan.esg_be.domain.point.dto.response.PointShopSummaryResponse;
+import com.shinhan.esg_be.domain.point.service.PointShopSummaryService;
+import com.shinhan.esg_be.global.security.AuthContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/point-shop")
+@RequiredArgsConstructor
+public class PointShopSummaryController {
+
+    private final PointShopSummaryService pointShopSummaryService;
+    private final AuthContext authContext;
+
+    @GetMapping("/summary")
+    public ResponseEntity<PointShopSummaryResponse> getSummary() {
+        return ResponseEntity.ok(pointShopSummaryService.getSummary(authContext.currentUserId()));
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/dto/response/PointShopItemResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/dto/response/PointShopItemResponse.java
@@ -1,0 +1,35 @@
+package com.shinhan.esg_be.domain.point.dto.response;
+
+import lombok.Getter;
+
+@Getter
+public class PointShopItemResponse {
+
+    private final Long itemId;
+    private final String name;
+    private final String category;
+    private final Long requiredPoints;
+    private final String imageUrl;
+    private final String description;
+    private final Integer stock;
+    private final Boolean soldOut;
+
+    public PointShopItemResponse(
+            Long itemId,
+            String name,
+            String category,
+            Long requiredPoints,
+            String imageUrl,
+            String description,
+            Integer stock
+    ) {
+        this.itemId = itemId;
+        this.name = name;
+        this.category = category;
+        this.requiredPoints = requiredPoints;
+        this.imageUrl = imageUrl;
+        this.description = description;
+        this.stock = stock;
+        this.soldOut = stock == null || stock <= 0;
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/dto/response/PointShopItemsResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/dto/response/PointShopItemsResponse.java
@@ -1,0 +1,13 @@
+package com.shinhan.esg_be.domain.point.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PointShopItemsResponse {
+
+    private final List<PointShopItemResponse> items;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/dto/response/PointShopPurchaseHistoryItemResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/dto/response/PointShopPurchaseHistoryItemResponse.java
@@ -1,0 +1,24 @@
+package com.shinhan.esg_be.domain.point.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 포인트샵 구매내역 한 건을 나타내는 응답 DTO
+ */
+@Getter
+@AllArgsConstructor
+public class PointShopPurchaseHistoryItemResponse {
+
+    private final Long userPointId;
+    private final Long itemId;
+    private final String itemName;
+    private final String category;
+    private final String imageUrl;
+    private final Long usedPoints;
+    private final Long pointAfter;
+    private final String exchangeCode;
+    private final LocalDateTime purchasedAt;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/dto/response/PointShopPurchaseHistoryResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/dto/response/PointShopPurchaseHistoryResponse.java
@@ -1,0 +1,16 @@
+package com.shinhan.esg_be.domain.point.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 포인트샵 구매내역 목록 응답 DTO
+ */
+@Getter
+@AllArgsConstructor
+public class PointShopPurchaseHistoryResponse {
+
+    private final List<PointShopPurchaseHistoryItemResponse> purchases;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/dto/response/PointShopPurchaseResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/dto/response/PointShopPurchaseResponse.java
@@ -1,0 +1,21 @@
+package com.shinhan.esg_be.domain.point.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+/**
+ * 포인트샵 상품 구매 성공 후 반환하는 응답 DTO
+ */
+@Getter
+@AllArgsConstructor
+public class PointShopPurchaseResponse {
+
+    private final Long itemId;
+    private final String itemName;
+    private final Long usedPoints;
+    private final Long remainingPoints;
+    private final String exchangeCode;
+    private final LocalDateTime purchasedAt;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/dto/response/PointShopSummaryResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/dto/response/PointShopSummaryResponse.java
@@ -1,0 +1,15 @@
+package com.shinhan.esg_be.domain.point.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 포인트샵에서 사용하는 현재 보유 포인트 응답 DTO
+ */
+@Getter
+@AllArgsConstructor
+public class PointShopSummaryResponse {
+
+    private final Long userId;
+    private final Long totalPoints;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/entity/Item.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/entity/Item.java
@@ -41,4 +41,11 @@ public class Item extends BaseTimeEntity {
 
     @Column(name = "is_active", nullable = false)
     private Boolean isActive;
+
+    public void decreaseStock() {
+        if (stock == null || stock <= 0) {
+            throw new IllegalStateException("차감할 수 있는 재고가 없습니다.");
+        }
+        stock -= 1;
+    }
 }

--- a/src/main/java/com/shinhan/esg_be/domain/point/entity/UserPoint.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/entity/UserPoint.java
@@ -52,6 +52,9 @@ public class UserPoint {
     @Column(name = "point_after", nullable = false)
     private Long pointAfter;
 
+    @Column(name = "exchange_code", unique = true, length = 100)
+    private String exchangeCode;
+
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
@@ -63,12 +66,24 @@ public class UserPoint {
             long changedAmount,
             long pointAfter
     ) {
+        return create(user, item, reason, changedAmount, pointAfter, null);
+    }
+
+    public static UserPoint create(
+            User user,
+            Item item,
+            PointReason reason,
+            long changedAmount,
+            long pointAfter,
+            String exchangeCode
+    ) {
         UserPoint userPoint = new UserPoint();
         userPoint.user = user;
         userPoint.item = item;
         userPoint.reason = reason;
         userPoint.changedAmount = changedAmount;
         userPoint.pointAfter = pointAfter;
+        userPoint.exchangeCode = exchangeCode;
         return userPoint;
     }
 }

--- a/src/main/java/com/shinhan/esg_be/domain/point/repository/ItemRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/repository/ItemRepository.java
@@ -1,0 +1,45 @@
+package com.shinhan.esg_be.domain.point.repository;
+
+import com.shinhan.esg_be.domain.point.dto.response.PointShopItemResponse;
+import com.shinhan.esg_be.domain.point.entity.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+
+    @Query("""
+            select new com.shinhan.esg_be.domain.point.dto.response.PointShopItemResponse(
+                i.itemId,
+                i.name,
+                i.category,
+                i.requiredPoints,
+                i.imageUrl,
+                i.description,
+                i.stock
+            )
+            from Item i
+            where i.isActive = true
+            order by i.itemId desc
+            """)
+    List<PointShopItemResponse> findActiveItems();
+
+    @Query("""
+            select new com.shinhan.esg_be.domain.point.dto.response.PointShopItemResponse(
+                i.itemId,
+                i.name,
+                i.category,
+                i.requiredPoints,
+                i.imageUrl,
+                i.description,
+                i.stock
+            )
+            from Item i
+            where i.itemId = :itemId
+              and i.isActive = true
+            """)
+    Optional<PointShopItemResponse> findActiveItem(@Param("itemId") Long itemId);
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/repository/UserPointRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/repository/UserPointRepository.java
@@ -4,12 +4,29 @@ import com.shinhan.esg_be.domain.point.entity.UserPoint;
 import com.shinhan.esg_be.domain.point.entity.enums.PointReason;
 import com.shinhan.esg_be.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.time.LocalDateTime;
 import java.util.Collection;
 import java.util.List;
 
 public interface UserPointRepository extends JpaRepository<UserPoint, Long> {
+
+    boolean existsByExchangeCode(String exchangeCode);
+
+    @Query("""
+            select up
+            from UserPoint up
+            join fetch up.item i
+            where up.user.userId = :userId
+              and up.reason = :reason
+            order by up.createdAt desc
+            """)
+    List<UserPoint> findPointShopPurchasesByUserIdAndReason(
+            @Param("userId") Long userId,
+            @Param("reason") PointReason reason
+    );
 
     long countByUserAndReason(User user, PointReason reason);
 

--- a/src/main/java/com/shinhan/esg_be/domain/point/service/PointShopItemService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/service/PointShopItemService.java
@@ -1,0 +1,28 @@
+package com.shinhan.esg_be.domain.point.service;
+
+import com.shinhan.esg_be.domain.point.dto.response.PointShopItemResponse;
+import com.shinhan.esg_be.domain.point.dto.response.PointShopItemsResponse;
+import com.shinhan.esg_be.domain.point.repository.ItemRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PointShopItemService {
+
+    private final ItemRepository itemRepository;
+
+    public PointShopItemsResponse getItems() {
+        return new PointShopItemsResponse(itemRepository.findActiveItems());
+    }
+
+    public PointShopItemResponse getItem(Long itemId) {
+        return itemRepository.findActiveItem(itemId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "상품을 찾을 수 없습니다."));
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/service/PointShopPurchaseHistoryService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/service/PointShopPurchaseHistoryService.java
@@ -1,0 +1,44 @@
+package com.shinhan.esg_be.domain.point.service;
+
+import com.shinhan.esg_be.domain.point.dto.response.PointShopPurchaseHistoryItemResponse;
+import com.shinhan.esg_be.domain.point.dto.response.PointShopPurchaseHistoryResponse;
+import com.shinhan.esg_be.domain.point.entity.UserPoint;
+import com.shinhan.esg_be.domain.point.entity.enums.PointReason;
+import com.shinhan.esg_be.domain.point.repository.UserPointRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PointShopPurchaseHistoryService {
+
+    private final UserPointRepository userPointRepository;
+
+    public PointShopPurchaseHistoryResponse getPurchases(Long userId) {
+        List<PointShopPurchaseHistoryItemResponse> purchases = userPointRepository
+                .findPointShopPurchasesByUserIdAndReason(userId, PointReason.EXCHANGE)
+                .stream()
+                .map(this::toResponse)
+                .toList();
+
+        return new PointShopPurchaseHistoryResponse(purchases);
+    }
+
+    private PointShopPurchaseHistoryItemResponse toResponse(UserPoint userPoint) {
+        return new PointShopPurchaseHistoryItemResponse(
+                userPoint.getExchangeId(),
+                userPoint.getItem().getItemId(),
+                userPoint.getItem().getName(),
+                userPoint.getItem().getCategory(),
+                userPoint.getItem().getImageUrl(),
+                Math.abs(userPoint.getChangedAmount()),
+                userPoint.getPointAfter(),
+                userPoint.getExchangeCode(),
+                userPoint.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/service/PointShopPurchaseService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/service/PointShopPurchaseService.java
@@ -1,0 +1,110 @@
+package com.shinhan.esg_be.domain.point.service;
+
+import com.shinhan.esg_be.domain.point.dto.response.PointShopPurchaseResponse;
+import com.shinhan.esg_be.domain.point.entity.Item;
+import com.shinhan.esg_be.domain.point.entity.UserPoint;
+import com.shinhan.esg_be.domain.point.entity.enums.PointReason;
+import com.shinhan.esg_be.domain.point.repository.UserPointRepository;
+import com.shinhan.esg_be.domain.user.entity.User;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.LockModeType;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.Locale;
+import java.util.UUID;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.CONFLICT;
+import static org.springframework.http.HttpStatus.INTERNAL_SERVER_ERROR;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class PointShopPurchaseService {
+
+    private static final String EXCHANGE_CODE_PREFIX = "SOLV-";
+    private static final int EXCHANGE_CODE_LENGTH = 8;
+    private static final int EXCHANGE_CODE_RETRY_COUNT = 10;
+
+    private final EntityManager entityManager;
+    private final UserPointRepository userPointRepository;
+
+    @Transactional
+    public PointShopPurchaseResponse purchase(Long userId, Long itemId) {
+        User user = getUserForUpdate(userId);
+        Item item = getItemForUpdate(itemId);
+
+        validatePurchasable(user, item);
+
+        long usedPoints = item.getRequiredPoints();
+        user.applyPoint((int) -usedPoints);
+        item.decreaseStock();
+
+        String exchangeCode = generateExchangeCode();
+        UserPoint savedUserPoint = userPointRepository.saveAndFlush(
+                UserPoint.create(
+                        user,
+                        item,
+                        PointReason.EXCHANGE,
+                        -usedPoints,
+                        user.getTotalPoints().longValue(),
+                        exchangeCode
+                )
+        );
+
+        return new PointShopPurchaseResponse(
+                item.getItemId(),
+                item.getName(),
+                usedPoints,
+                user.getTotalPoints().longValue(),
+                exchangeCode,
+                savedUserPoint.getCreatedAt()
+        );
+    }
+
+    private User getUserForUpdate(Long userId) {
+        User user = entityManager.find(User.class, userId, LockModeType.PESSIMISTIC_WRITE);
+        if (user == null) {
+            throw new ResponseStatusException(NOT_FOUND, "사용자 정보를 찾을 수 없습니다.");
+        }
+        return user;
+    }
+
+    private Item getItemForUpdate(Long itemId) {
+        Item item = entityManager.find(Item.class, itemId, LockModeType.PESSIMISTIC_WRITE);
+        if (item == null || !Boolean.TRUE.equals(item.getIsActive())) {
+            throw new ResponseStatusException(NOT_FOUND, "상품 정보를 찾을 수 없습니다.");
+        }
+        return item;
+    }
+
+    private void validatePurchasable(User user, Item item) {
+        if (item.getStock() == null || item.getStock() <= 0) {
+            throw new ResponseStatusException(CONFLICT, "품절된 상품입니다.");
+        }
+
+        long totalPoints = user.getTotalPoints().longValue();
+        if (totalPoints < item.getRequiredPoints()) {
+            throw new ResponseStatusException(BAD_REQUEST, "포인트가 부족합니다.");
+        }
+    }
+
+    private String generateExchangeCode() {
+        for (int attempt = 0; attempt < EXCHANGE_CODE_RETRY_COUNT; attempt++) {
+            String exchangeCode = EXCHANGE_CODE_PREFIX + UUID.randomUUID()
+                    .toString()
+                    .replace("-", "")
+                    .substring(0, EXCHANGE_CODE_LENGTH)
+                    .toUpperCase(Locale.ROOT);
+
+            if (!userPointRepository.existsByExchangeCode(exchangeCode)) {
+                return exchangeCode;
+            }
+        }
+
+        throw new ResponseStatusException(INTERNAL_SERVER_ERROR, "교환 코드 생성에 실패했습니다.");
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/service/PointShopSummaryService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/service/PointShopSummaryService.java
@@ -1,0 +1,29 @@
+package com.shinhan.esg_be.domain.point.service;
+
+import com.shinhan.esg_be.domain.point.dto.response.PointShopSummaryResponse;
+import com.shinhan.esg_be.domain.user.entity.User;
+import com.shinhan.esg_be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class PointShopSummaryService {
+
+    private final UserRepository userRepository;
+
+    public PointShopSummaryResponse getSummary(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "사용자 정보를 찾을 수 없습니다."));
+
+        return new PointShopSummaryResponse(
+                user.getUserId(),
+                user.getTotalPoints().longValue()
+        );
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #36

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- 포인트샵 목록, 상세, 구매내역 화면을 API와 연동
- 포인트샵 구매 플로우와 보유 포인트 표시를 실데이터 기준으로 연결

## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->
ointShopService, pointShop 타입, usePointShopSummary 훅을 추가
ShopListPage, ShopProductDetailView, ShopHistoryPage에서 mock 데이터를 제거하고 포인트샵 API를 사용하도록 변경
구매 확인 모달에서 실제 구매 API를 호출하고, 구매 완료 화면 및 일부 공용 이미지 경로를 S3 기준으로 변경

## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [x] 로컬에서 정상 동작 확인
- [x] API 테스트 완료 (해당되면)
- [x] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
