### PR TITLE
메인 대시보드 요약 조회 API 구현

### DIFF
--- a/src/main/java/com/shinhan/esg_be/domain/home/controller/HomeDashboardController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/home/controller/HomeDashboardController.java
@@ -1,0 +1,27 @@
+package com.shinhan.esg_be.domain.home.controller;
+
+import com.shinhan.esg_be.domain.home.dto.response.HomeDashboardSummaryResponse;
+import com.shinhan.esg_be.domain.home.service.HomeDashboardService;
+import com.shinhan.esg_be.global.security.AuthContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 홈 대시보드 관련 API를 담당하는 컨트롤러
+ */
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/home")
+public class HomeDashboardController {
+
+    private final HomeDashboardService homeDashboardService;
+    private final AuthContext authContext;
+
+    @GetMapping("/summary")
+    public ResponseEntity<HomeDashboardSummaryResponse> getSummary() {
+        return ResponseEntity.ok(homeDashboardService.getSummary(authContext.currentUserId()));
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/home/dto/response/GradeProgressResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/home/dto/response/GradeProgressResponse.java
@@ -1,0 +1,16 @@
+package com.shinhan.esg_be.domain.home.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 홈 대시보드 등급 진행도 정보를 담는 응답 DTO
+ */
+@Getter
+@AllArgsConstructor
+public class GradeProgressResponse {
+
+    private final Integer current;
+    private final Integer target;
+    private final Integer visualValue;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/home/dto/response/HomeDashboardSummaryResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/home/dto/response/HomeDashboardSummaryResponse.java
@@ -1,0 +1,21 @@
+package com.shinhan.esg_be.domain.home.dto.response;
+
+import com.shinhan.esg_be.domain.user.entity.enums.Grade;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 홈 화면에서 사용하는 대시보드 요약 정보를 담는 응답 DTO
+ */
+@Getter
+@AllArgsConstructor
+public class HomeDashboardSummaryResponse {
+
+    private final String name;
+    private final Grade currentGrade;
+    private final Integer totalPoints;
+    private final GradeProgressResponse gradeProgress;
+    private final List<WeeklyActivityStatusResponse> weeklyActivities;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/home/dto/response/WeeklyActivityStatusResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/home/dto/response/WeeklyActivityStatusResponse.java
@@ -1,0 +1,15 @@
+package com.shinhan.esg_be.domain.home.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 홈 대시보드 주간 활동 체크 상태를 담는 응답 DTO
+ */
+@Getter
+@AllArgsConstructor
+public class WeeklyActivityStatusResponse {
+
+    private final String day;
+    private final boolean completed;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/home/service/HomeDashboardService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/home/service/HomeDashboardService.java
@@ -1,0 +1,167 @@
+package com.shinhan.esg_be.domain.home.service;
+
+import com.shinhan.esg_be.domain.home.dto.response.GradeProgressResponse;
+import com.shinhan.esg_be.domain.home.dto.response.HomeDashboardSummaryResponse;
+import com.shinhan.esg_be.domain.home.dto.response.WeeklyActivityStatusResponse;
+import com.shinhan.esg_be.domain.score.entity.ValidScoreHistory;
+import com.shinhan.esg_be.domain.user.entity.User;
+import com.shinhan.esg_be.domain.user.entity.enums.Grade;
+import com.shinhan.esg_be.domain.user.repository.UserRepository;
+import com.shinhan.esg_be.global.common.enums.ScoreReason;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Clock;
+import java.time.DayOfWeek;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.temporal.TemporalAdjusters;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class HomeDashboardService {
+
+    private static final int MAX_SCORE = 1000;
+
+    private static final Set<ScoreReason> HOME_ACTIVITY_REASONS = EnumSet.of(
+            ScoreReason.DONATION,
+            ScoreReason.VOLUNTEER,
+            ScoreReason.PURCHASE,
+            ScoreReason.QUIZ,
+            ScoreReason.PHOTO,
+            ScoreReason.LOAN_REPAY
+    );
+
+    private final UserRepository userRepository;
+    private final EntityManager entityManager;
+    private final Clock clock;
+
+    public HomeDashboardSummaryResponse getSummary(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "사용자 정보를 찾을 수 없습니다."));
+
+        int totalScore = user.getTotalScore();
+        Grade currentGrade = resolveCurrentGrade(totalScore);
+
+        return new HomeDashboardSummaryResponse(
+                user.getName(),
+                currentGrade,
+                user.getTotalPoints(),
+                buildGradeProgress(totalScore, currentGrade),
+                buildWeeklyActivities(userId)
+        );
+    }
+
+    private GradeProgressResponse buildGradeProgress(int totalScore, Grade currentGrade) {
+        int displayScore = Math.max(0, Math.min(totalScore, MAX_SCORE));
+        int target = resolveNextThreshold(currentGrade);
+        int segmentCurrent = switch (currentGrade) {
+            case SEED -> Math.max(0, Math.min(displayScore, 600));
+            case SPROUT -> Math.max(0, Math.min(displayScore - 600, 100));
+            case TREE -> Math.max(0, Math.min(displayScore - 700, 100));
+            case FOREST -> Math.max(0, Math.min(displayScore - 800, 100));
+            case EARTH -> Math.max(0, Math.min(displayScore - 900, 100));
+        };
+        int segmentTarget = currentGrade == Grade.SEED ? 600 : 100;
+        int visualValue = segmentTarget == 0
+                ? 0
+                : (int) Math.round((segmentCurrent * 100.0) / segmentTarget);
+
+        return new GradeProgressResponse(
+                displayScore,
+                target,
+                Math.min(100, Math.max(0, visualValue))
+        );
+    }
+
+    private Grade resolveCurrentGrade(int totalScore) {
+        if (totalScore >= 900) {
+            return Grade.EARTH;
+        }
+        if (totalScore >= 800) {
+            return Grade.FOREST;
+        }
+        if (totalScore >= 700) {
+            return Grade.TREE;
+        }
+        if (totalScore >= 600) {
+            return Grade.SPROUT;
+        }
+        return Grade.SEED;
+    }
+
+    private int resolveNextThreshold(Grade currentGrade) {
+        return switch (currentGrade) {
+            case SEED -> 600;
+            case SPROUT -> 700;
+            case TREE -> 800;
+            case FOREST -> 900;
+            case EARTH -> 1000;
+        };
+    }
+
+    private List<WeeklyActivityStatusResponse> buildWeeklyActivities(Long userId) {
+        LocalDate today = LocalDate.now(clock);
+        LocalDate weekStartDate = today.with(TemporalAdjusters.previousOrSame(DayOfWeek.MONDAY));
+        LocalDateTime weekStart = weekStartDate.atStartOfDay();
+        LocalDateTime weekEnd = weekStartDate.plusDays(7).atStartOfDay();
+
+        Set<LocalDate> activityDates = entityManager.createQuery("""
+                        select v
+                        from ValidScoreHistory v
+                        where v.user.userId = :userId
+                          and v.reason in :reasons
+                          and v.createdAt >= :weekStart
+                          and v.createdAt < :weekEnd
+                        """, ValidScoreHistory.class)
+                .setParameter("userId", userId)
+                .setParameter("reasons", HOME_ACTIVITY_REASONS)
+                .setParameter("weekStart", weekStart)
+                .setParameter("weekEnd", weekEnd)
+                .getResultList()
+                .stream()
+                .map(ValidScoreHistory::getCreatedAt)
+                .map(LocalDateTime::toLocalDate)
+                .collect(Collectors.toSet());
+
+        return List.of(
+                DayOfWeek.MONDAY,
+                DayOfWeek.TUESDAY,
+                DayOfWeek.WEDNESDAY,
+                DayOfWeek.THURSDAY,
+                DayOfWeek.FRIDAY,
+                DayOfWeek.SATURDAY,
+                DayOfWeek.SUNDAY
+        ).stream()
+                .map(dayOfWeek -> {
+                    LocalDate targetDate = weekStartDate.with(TemporalAdjusters.nextOrSame(dayOfWeek));
+                    return new WeeklyActivityStatusResponse(
+                            toKoreanDayLabel(dayOfWeek),
+                            activityDates.contains(targetDate)
+                    );
+                })
+                .toList();
+    }
+
+    private String toKoreanDayLabel(DayOfWeek dayOfWeek) {
+        return switch (dayOfWeek) {
+            case MONDAY -> "월";
+            case TUESDAY -> "화";
+            case WEDNESDAY -> "수";
+            case THURSDAY -> "목";
+            case FRIDAY -> "금";
+            case SATURDAY -> "토";
+            case SUNDAY -> "일";
+        };
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #43

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- 메인 대시보드에서 사용할 요약 조회 API 추가
- 사용자 점수, 등급 진행률, 이번 주 활동 데이터를 실데이터 기준으로 조회

## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->
home 도메인에 controller, service, response DTO 추가
사용자 총점 기준으로 현재 등급과 다음 등급까지의 진행률 계산
valid_score_history를 기준으로 이번 주 활동 여부를 요일별로 집계

## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [x] 로컬에서 정상 동작 확인
- [x] API 테스트 완료 (해당되면)
- [x] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
