### PR TITLE
42 feat 금융 마이페이지 및 이력 조회 api 구현

### DIFF
--- a/src/main/java/com/shinhan/esg_be/domain/bank/controller/FinanceController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/controller/FinanceController.java
@@ -1,5 +1,6 @@
 package com.shinhan.esg_be.domain.bank.controller;
 
+import com.shinhan.esg_be.domain.bank.dto.response.FinanceMyResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.FinanceProductListResponse;
 import com.shinhan.esg_be.domain.bank.service.FinanceService;
 import lombok.RequiredArgsConstructor;
@@ -16,6 +17,13 @@ import org.springframework.web.bind.annotation.RestController;
 public class FinanceController {
 
     private final FinanceService financeService;
+
+    @GetMapping("/my")
+    public ResponseEntity<FinanceMyResponse> getMyFinance(
+            @AuthenticationPrincipal String loginId
+    ) {
+        return ResponseEntity.ok(financeService.getMyFinance(loginId));
+    }
 
     @GetMapping("/list")
     public ResponseEntity<FinanceProductListResponse> getFinanceProducts(

--- a/src/main/java/com/shinhan/esg_be/domain/bank/controller/FinanceController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/controller/FinanceController.java
@@ -1,5 +1,6 @@
 package com.shinhan.esg_be.domain.bank.controller;
 
+import com.shinhan.esg_be.domain.bank.dto.response.FinanceHistoryResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.FinanceMyResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.FinanceProductListResponse;
 import com.shinhan.esg_be.domain.bank.service.FinanceService;
@@ -23,6 +24,13 @@ public class FinanceController {
             @AuthenticationPrincipal String loginId
     ) {
         return ResponseEntity.ok(financeService.getMyFinance(loginId));
+    }
+
+    @GetMapping("/history")
+    public ResponseEntity<FinanceHistoryResponse> getFinanceHistory(
+            @AuthenticationPrincipal String loginId
+    ) {
+        return ResponseEntity.ok(financeService.getFinanceHistory(loginId));
     }
 
     @GetMapping("/list")

--- a/src/main/java/com/shinhan/esg_be/domain/bank/dto/response/ActiveLoanResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/dto/response/ActiveLoanResponse.java
@@ -1,0 +1,19 @@
+package com.shinhan.esg_be.domain.bank.dto.response;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record ActiveLoanResponse(
+        Long loanId,
+        Long productId,
+        String productName,
+        Long principalAmount,
+        Long totalAmount,
+        BigDecimal currentRate,
+        String status,
+        Integer durationMonths,
+        LocalDate nextRepaymentDate,
+        LocalDateTime joinedAt
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/bank/dto/response/ActiveSavingResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/dto/response/ActiveSavingResponse.java
@@ -1,0 +1,17 @@
+package com.shinhan.esg_be.domain.bank.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+public record ActiveSavingResponse(
+        Long savingId,
+        Long productId,
+        String productName,
+        Long monthlyAmount,
+        String status,
+        Integer durationMonths,
+        Boolean hasPenalty,
+        LocalDate maturityDate,
+        LocalDateTime joinedAt
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/bank/dto/response/FinanceHistoryResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/dto/response/FinanceHistoryResponse.java
@@ -1,0 +1,9 @@
+package com.shinhan.esg_be.domain.bank.dto.response;
+
+import java.util.List;
+
+public record FinanceHistoryResponse(
+        List<LoanHistoryResponse> loans,
+        List<SavingHistoryResponse> savings
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/bank/dto/response/FinanceMyResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/dto/response/FinanceMyResponse.java
@@ -1,0 +1,7 @@
+package com.shinhan.esg_be.domain.bank.dto.response;
+
+public record FinanceMyResponse(
+        ActiveLoanResponse activeLoan,
+        ActiveSavingResponse activeSaving
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/bank/dto/response/LoanHistoryResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/dto/response/LoanHistoryResponse.java
@@ -1,0 +1,13 @@
+package com.shinhan.esg_be.domain.bank.dto.response;
+
+import java.time.LocalDateTime;
+
+public record LoanHistoryResponse(
+        Long historyId,
+        Long loanId,
+        Long productId,
+        String productName,
+        Long amount,
+        LocalDateTime paymentDate
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/bank/dto/response/SavingHistoryResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/dto/response/SavingHistoryResponse.java
@@ -1,0 +1,13 @@
+package com.shinhan.esg_be.domain.bank.dto.response;
+
+import java.time.LocalDateTime;
+
+public record SavingHistoryResponse(
+        Long historyId,
+        Long savingId,
+        Long productId,
+        String productName,
+        Long amount,
+        LocalDateTime paymentDate
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/bank/repository/LoanHistoryRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/repository/LoanHistoryRepository.java
@@ -1,0 +1,20 @@
+package com.shinhan.esg_be.domain.bank.repository;
+
+import com.shinhan.esg_be.domain.bank.entity.LoanHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface LoanHistoryRepository extends JpaRepository<LoanHistory, Long> {
+
+    @Query("""
+            select loanHistory
+            from LoanHistory loanHistory
+            join fetch loanHistory.userLoan userLoan
+            join fetch userLoan.financialProduct
+            where userLoan.user.userId = :userId
+            order by loanHistory.paymentDate desc
+            """)
+    List<LoanHistory> findAllByUserId(Long userId);
+}

--- a/src/main/java/com/shinhan/esg_be/domain/bank/repository/SavingHistoryRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/repository/SavingHistoryRepository.java
@@ -1,0 +1,20 @@
+package com.shinhan.esg_be.domain.bank.repository;
+
+import com.shinhan.esg_be.domain.bank.entity.SavingHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface SavingHistoryRepository extends JpaRepository<SavingHistory, Long> {
+
+    @Query("""
+            select savingHistory
+            from SavingHistory savingHistory
+            join fetch savingHistory.userSaving userSaving
+            join fetch userSaving.financialProduct
+            where userSaving.user.userId = :userId
+            order by savingHistory.paymentDate desc
+            """)
+    List<SavingHistory> findAllByUserId(Long userId);
+}

--- a/src/main/java/com/shinhan/esg_be/domain/bank/repository/UserLoanRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/repository/UserLoanRepository.java
@@ -3,6 +3,7 @@ package com.shinhan.esg_be.domain.bank.repository;
 import com.shinhan.esg_be.domain.bank.entity.UserLoan;
 import com.shinhan.esg_be.domain.bank.entity.enums.LoanStatus;
 import com.shinhan.esg_be.domain.user.entity.User;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.List;
@@ -12,5 +13,6 @@ public interface UserLoanRepository extends JpaRepository<UserLoan, Long> {
 
     List<UserLoan> findByUserAndStatus(User user, LoanStatus status);
 
+    @EntityGraph(attributePaths = "financialProduct")
     Optional<UserLoan> findByUser_UserIdAndStatus(Long userId, LoanStatus status);
 }

--- a/src/main/java/com/shinhan/esg_be/domain/bank/repository/UserSavingRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/repository/UserSavingRepository.java
@@ -2,11 +2,13 @@ package com.shinhan.esg_be.domain.bank.repository;
 
 import com.shinhan.esg_be.domain.bank.entity.UserSaving;
 import com.shinhan.esg_be.domain.bank.entity.enums.SavingStatus;
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.Optional;
 
 public interface UserSavingRepository extends JpaRepository<UserSaving, Long> {
 
+    @EntityGraph(attributePaths = "financialProduct")
     Optional<UserSaving> findByUser_UserIdAndStatus(Long userId, SavingStatus status);
 }

--- a/src/main/java/com/shinhan/esg_be/domain/bank/service/FinanceService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/service/FinanceService.java
@@ -1,12 +1,19 @@
 package com.shinhan.esg_be.domain.bank.service;
 
+import com.shinhan.esg_be.domain.bank.dto.response.ActiveLoanResponse;
+import com.shinhan.esg_be.domain.bank.dto.response.ActiveSavingResponse;
+import com.shinhan.esg_be.domain.bank.dto.response.FinanceMyResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.FinanceProductListResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.FinanceProductResponse;
 import com.shinhan.esg_be.domain.bank.entity.FinancialProduct;
+import com.shinhan.esg_be.domain.bank.entity.UserLoan;
+import com.shinhan.esg_be.domain.bank.entity.UserSaving;
 import com.shinhan.esg_be.domain.bank.entity.enums.LoanStatus;
 import com.shinhan.esg_be.domain.bank.entity.enums.ProductType;
+import com.shinhan.esg_be.domain.bank.entity.enums.SavingStatus;
 import com.shinhan.esg_be.domain.bank.repository.FinancialProductRepository;
 import com.shinhan.esg_be.domain.bank.repository.UserLoanRepository;
+import com.shinhan.esg_be.domain.bank.repository.UserSavingRepository;
 import com.shinhan.esg_be.domain.user.entity.User;
 import com.shinhan.esg_be.domain.user.repository.UserRepository;
 import com.shinhan.esg_be.global.exception.BadRequestException;
@@ -32,11 +39,25 @@ public class FinanceService {
 
     private final FinancialProductRepository financialProductRepository;
     private final UserLoanRepository userLoanRepository;
+    private final UserSavingRepository userSavingRepository;
     private final UserRepository userRepository;
 
+    public FinanceMyResponse getMyFinance(String loginId) {
+        User user = getUser(loginId);
+
+        ActiveLoanResponse activeLoan = userLoanRepository.findByUser_UserIdAndStatus(user.getUserId(), LoanStatus.ACTIVE)
+                .map(this::toActiveLoanResponse)
+                .orElse(null);
+
+        ActiveSavingResponse activeSaving = userSavingRepository.findByUser_UserIdAndStatus(user.getUserId(), SavingStatus.ACTIVE)
+                .map(this::toActiveSavingResponse)
+                .orElse(null);
+
+        return new FinanceMyResponse(activeLoan, activeSaving);
+    }
+
     public FinanceProductListResponse getFinanceProducts(String loginId, String type) {
-        User user = userRepository.findByLoginId(loginId)
-                .orElseThrow(() -> new IllegalArgumentException("User not found."));
+        User user = getUser(loginId);
 
         ProductType productType = parseProductType(type);
         var products = financialProductRepository.findByTypeAndIsActiveTrue(productType)
@@ -85,6 +106,37 @@ public class FinanceService {
         );
     }
 
+    private ActiveLoanResponse toActiveLoanResponse(UserLoan userLoan) {
+        FinancialProduct product = userLoan.getFinancialProduct();
+        return new ActiveLoanResponse(
+                userLoan.getLoanId(),
+                product.getFinProductId(),
+                product.getName(),
+                userLoan.getPrincipalAmount(),
+                userLoan.getTotalAmount(),
+                userLoan.getCurrentRate(),
+                userLoan.getStatus().name(),
+                product.getDurationMonths(),
+                userLoan.getNextRepaymentDate(),
+                userLoan.getCreatedAt()
+        );
+    }
+
+    private ActiveSavingResponse toActiveSavingResponse(UserSaving userSaving) {
+        FinancialProduct product = userSaving.getFinancialProduct();
+        return new ActiveSavingResponse(
+                userSaving.getSavingId(),
+                product.getFinProductId(),
+                product.getName(),
+                userSaving.getMonthlyAmount(),
+                userSaving.getStatus().name(),
+                product.getDurationMonths(),
+                userSaving.getHasPenalty(),
+                userSaving.getMaturityDate(),
+                userSaving.getJoinedAt()
+        );
+    }
+
     private LoanOffer calculateLoanOffer(User user) {
         int totalScore = user.getTotalScore();
         if (totalScore >= 900) {
@@ -110,6 +162,11 @@ public class FinanceService {
             return ProductType.SAVINGS;
         }
         throw new BadRequestException("Invalid product type.");
+    }
+
+    private User getUser(String loginId) {
+        return userRepository.findByLoginId(loginId)
+                .orElseThrow(() -> new BadRequestException("User not found."));
     }
 
     private record LoanOffer(

--- a/src/main/java/com/shinhan/esg_be/domain/bank/service/FinanceService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/service/FinanceService.java
@@ -2,16 +2,23 @@ package com.shinhan.esg_be.domain.bank.service;
 
 import com.shinhan.esg_be.domain.bank.dto.response.ActiveLoanResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.ActiveSavingResponse;
+import com.shinhan.esg_be.domain.bank.dto.response.FinanceHistoryResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.FinanceMyResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.FinanceProductListResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.FinanceProductResponse;
+import com.shinhan.esg_be.domain.bank.dto.response.LoanHistoryResponse;
+import com.shinhan.esg_be.domain.bank.dto.response.SavingHistoryResponse;
 import com.shinhan.esg_be.domain.bank.entity.FinancialProduct;
+import com.shinhan.esg_be.domain.bank.entity.LoanHistory;
+import com.shinhan.esg_be.domain.bank.entity.SavingHistory;
 import com.shinhan.esg_be.domain.bank.entity.UserLoan;
 import com.shinhan.esg_be.domain.bank.entity.UserSaving;
 import com.shinhan.esg_be.domain.bank.entity.enums.LoanStatus;
 import com.shinhan.esg_be.domain.bank.entity.enums.ProductType;
 import com.shinhan.esg_be.domain.bank.entity.enums.SavingStatus;
 import com.shinhan.esg_be.domain.bank.repository.FinancialProductRepository;
+import com.shinhan.esg_be.domain.bank.repository.LoanHistoryRepository;
+import com.shinhan.esg_be.domain.bank.repository.SavingHistoryRepository;
 import com.shinhan.esg_be.domain.bank.repository.UserLoanRepository;
 import com.shinhan.esg_be.domain.bank.repository.UserSavingRepository;
 import com.shinhan.esg_be.domain.user.entity.User;
@@ -38,6 +45,8 @@ public class FinanceService {
     private static final BigDecimal LOAN_RATE_900 = new BigDecimal("6.00");
 
     private final FinancialProductRepository financialProductRepository;
+    private final LoanHistoryRepository loanHistoryRepository;
+    private final SavingHistoryRepository savingHistoryRepository;
     private final UserLoanRepository userLoanRepository;
     private final UserSavingRepository userSavingRepository;
     private final UserRepository userRepository;
@@ -54,6 +63,22 @@ public class FinanceService {
                 .orElse(null);
 
         return new FinanceMyResponse(activeLoan, activeSaving);
+    }
+
+    public FinanceHistoryResponse getFinanceHistory(String loginId) {
+        User user = getUser(loginId);
+
+        List<LoanHistoryResponse> loans = loanHistoryRepository.findAllByUserId(user.getUserId())
+                .stream()
+                .map(this::toLoanHistoryResponse)
+                .toList();
+
+        List<SavingHistoryResponse> savings = savingHistoryRepository.findAllByUserId(user.getUserId())
+                .stream()
+                .map(this::toSavingHistoryResponse)
+                .toList();
+
+        return new FinanceHistoryResponse(loans, savings);
     }
 
     public FinanceProductListResponse getFinanceProducts(String loginId, String type) {
@@ -134,6 +159,32 @@ public class FinanceService {
                 userSaving.getHasPenalty(),
                 userSaving.getMaturityDate(),
                 userSaving.getJoinedAt()
+        );
+    }
+
+    private LoanHistoryResponse toLoanHistoryResponse(LoanHistory loanHistory) {
+        UserLoan userLoan = loanHistory.getUserLoan();
+        FinancialProduct product = userLoan.getFinancialProduct();
+        return new LoanHistoryResponse(
+                loanHistory.getId(),
+                userLoan.getLoanId(),
+                product.getFinProductId(),
+                product.getName(),
+                loanHistory.getAmount(),
+                loanHistory.getPaymentDate()
+        );
+    }
+
+    private SavingHistoryResponse toSavingHistoryResponse(SavingHistory savingHistory) {
+        UserSaving userSaving = savingHistory.getUserSaving();
+        FinancialProduct product = userSaving.getFinancialProduct();
+        return new SavingHistoryResponse(
+                savingHistory.getId(),
+                userSaving.getSavingId(),
+                product.getFinProductId(),
+                product.getName(),
+                savingHistory.getAmount(),
+                savingHistory.getPaymentDate()
         );
     }
 

--- a/src/test/java/com/shinhan/esg_be/domain/bank/controller/FinanceControllerTest.java
+++ b/src/test/java/com/shinhan/esg_be/domain/bank/controller/FinanceControllerTest.java
@@ -2,9 +2,12 @@ package com.shinhan.esg_be.domain.bank.controller;
 
 import com.shinhan.esg_be.domain.bank.dto.response.ActiveLoanResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.ActiveSavingResponse;
+import com.shinhan.esg_be.domain.bank.dto.response.FinanceHistoryResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.FinanceMyResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.FinanceProductListResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.FinanceProductResponse;
+import com.shinhan.esg_be.domain.bank.dto.response.LoanHistoryResponse;
+import com.shinhan.esg_be.domain.bank.dto.response.SavingHistoryResponse;
 import com.shinhan.esg_be.domain.bank.service.FinanceService;
 import com.shinhan.esg_be.global.exception.GlobalExceptionHandler;
 import org.junit.jupiter.api.BeforeEach;
@@ -86,6 +89,38 @@ class FinanceControllerTest {
                 .andExpect(jsonPath("$.activeLoan.productName").value("ESG 소액대출"))
                 .andExpect(jsonPath("$.activeSaving.savingId").value(20))
                 .andExpect(jsonPath("$.activeSaving.productName").value("그린 스텝업 적금"));
+    }
+
+    @Test
+    @DisplayName("금융 이력 조회 API는 대출 및 적금 이력을 반환한다")
+    void getFinanceHistory() throws Exception {
+        FinanceHistoryResponse response = new FinanceHistoryResponse(
+                List.of(new LoanHistoryResponse(
+                        1L,
+                        10L,
+                        1L,
+                        "ESG 소액대출",
+                        100_000L,
+                        LocalDateTime.of(2026, 4, 10, 9, 0)
+                )),
+                List.of(new SavingHistoryResponse(
+                        2L,
+                        20L,
+                        2L,
+                        "그린 스텝업 적금",
+                        300_000L,
+                        LocalDateTime.of(2026, 4, 10, 9, 0)
+                ))
+        );
+
+        given(financeService.getFinanceHistory(isNull())).willReturn(response);
+
+        mockMvc.perform(get("/api/v1/finance/history"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.loans[0].historyId").value(1))
+                .andExpect(jsonPath("$.loans[0].productName").value("ESG 소액대출"))
+                .andExpect(jsonPath("$.savings[0].historyId").value(2))
+                .andExpect(jsonPath("$.savings[0].productName").value("그린 스텝업 적금"));
     }
 
     @Test

--- a/src/test/java/com/shinhan/esg_be/domain/bank/controller/FinanceControllerTest.java
+++ b/src/test/java/com/shinhan/esg_be/domain/bank/controller/FinanceControllerTest.java
@@ -1,5 +1,8 @@
 package com.shinhan.esg_be.domain.bank.controller;
 
+import com.shinhan.esg_be.domain.bank.dto.response.ActiveLoanResponse;
+import com.shinhan.esg_be.domain.bank.dto.response.ActiveSavingResponse;
+import com.shinhan.esg_be.domain.bank.dto.response.FinanceMyResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.FinanceProductListResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.FinanceProductResponse;
 import com.shinhan.esg_be.domain.bank.service.FinanceService;
@@ -16,6 +19,8 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 
 import static org.mockito.ArgumentMatchers.eq;
@@ -45,7 +50,46 @@ class FinanceControllerTest {
     }
 
     @Test
-    @DisplayName("금융 상품 조회 API는 상품 목록을 반환한다")
+    @DisplayName("마이페이지 금융상품 조회 API는 활성 대출과 적금 정보를 반환한다")
+    void getMyFinance() throws Exception {
+        FinanceMyResponse response = new FinanceMyResponse(
+                new ActiveLoanResponse(
+                        10L,
+                        1L,
+                        "ESG 소액대출",
+                        1_500_000L,
+                        1_605_000L,
+                        new BigDecimal("7.00"),
+                        "ACTIVE",
+                        12,
+                        LocalDate.of(2026, 5, 1),
+                        LocalDateTime.of(2026, 4, 1, 0, 0)
+                ),
+                new ActiveSavingResponse(
+                        20L,
+                        2L,
+                        "그린 스텝업 적금",
+                        300_000L,
+                        "ACTIVE",
+                        12,
+                        false,
+                        LocalDate.of(2027, 4, 1),
+                        LocalDateTime.of(2026, 4, 1, 0, 0)
+                )
+        );
+
+        given(financeService.getMyFinance(isNull())).willReturn(response);
+
+        mockMvc.perform(get("/api/v1/finance/my"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.activeLoan.loanId").value(10))
+                .andExpect(jsonPath("$.activeLoan.productName").value("ESG 소액대출"))
+                .andExpect(jsonPath("$.activeSaving.savingId").value(20))
+                .andExpect(jsonPath("$.activeSaving.productName").value("그린 스텝업 적금"));
+    }
+
+    @Test
+    @DisplayName("금융상품 조회 API는 상품 목록을 반환한다")
     void getFinanceProducts() throws Exception {
         FinanceProductResponse response = new FinanceProductResponse(
                 1L,

--- a/src/test/java/com/shinhan/esg_be/domain/bank/service/FinanceServiceTest.java
+++ b/src/test/java/com/shinhan/esg_be/domain/bank/service/FinanceServiceTest.java
@@ -1,14 +1,19 @@
 package com.shinhan.esg_be.domain.bank.service;
 
+import com.shinhan.esg_be.domain.bank.dto.response.FinanceHistoryResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.FinanceMyResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.FinanceProductListResponse;
 import com.shinhan.esg_be.domain.bank.entity.FinancialProduct;
+import com.shinhan.esg_be.domain.bank.entity.LoanHistory;
+import com.shinhan.esg_be.domain.bank.entity.SavingHistory;
 import com.shinhan.esg_be.domain.bank.entity.UserLoan;
 import com.shinhan.esg_be.domain.bank.entity.UserSaving;
 import com.shinhan.esg_be.domain.bank.entity.enums.LoanStatus;
 import com.shinhan.esg_be.domain.bank.entity.enums.ProductType;
 import com.shinhan.esg_be.domain.bank.entity.enums.SavingStatus;
 import com.shinhan.esg_be.domain.bank.repository.FinancialProductRepository;
+import com.shinhan.esg_be.domain.bank.repository.LoanHistoryRepository;
+import com.shinhan.esg_be.domain.bank.repository.SavingHistoryRepository;
 import com.shinhan.esg_be.domain.bank.repository.UserLoanRepository;
 import com.shinhan.esg_be.domain.bank.repository.UserSavingRepository;
 import com.shinhan.esg_be.domain.user.entity.User;
@@ -39,6 +44,12 @@ class FinanceServiceTest {
 
     @Mock
     private FinancialProductRepository financialProductRepository;
+
+    @Mock
+    private LoanHistoryRepository loanHistoryRepository;
+
+    @Mock
+    private SavingHistoryRepository savingHistoryRepository;
 
     @Mock
     private UserLoanRepository userLoanRepository;
@@ -79,6 +90,39 @@ class FinanceServiceTest {
         assertThat(response.activeSaving().savingId()).isEqualTo(202L);
         assertThat(response.activeSaving().productId()).isEqualTo(22L);
         assertThat(response.activeSaving().productName()).isEqualTo("그린 스텝업 적금");
+    }
+
+    @Test
+    @DisplayName("금융 이력 조회는 대출 상환 이력과 적금 납입 이력을 함께 반환한다")
+    void getFinanceHistory() {
+        User user = createUser("finance-user-history", 100, 500, 100, 100);
+        ReflectionTestUtils.setField(user, "userId", 1L);
+
+        FinancialProduct loanProduct = createFinancialProduct("ESG 소액대출", ProductType.LOAN, "8.50", "8.50", 12);
+        ReflectionTestUtils.setField(loanProduct, "finProductId", 11L);
+        UserLoan userLoan = createUserLoan(user, loanProduct);
+        ReflectionTestUtils.setField(userLoan, "loanId", 101L);
+
+        FinancialProduct savingProduct = createFinancialProduct("그린 스텝업 적금", ProductType.SAVINGS, "2.00", "4.40", 12);
+        ReflectionTestUtils.setField(savingProduct, "finProductId", 22L);
+        UserSaving userSaving = createUserSaving(user, savingProduct);
+        ReflectionTestUtils.setField(userSaving, "savingId", 202L);
+
+        LoanHistory loanHistory = createLoanHistory(userLoan, 1L, 100_000L, LocalDateTime.of(2026, 4, 10, 9, 0));
+        SavingHistory savingHistory = createSavingHistory(userSaving, 2L, 300_000L, LocalDateTime.of(2026, 4, 11, 9, 0));
+
+        given(userRepository.findByLoginId(user.getLoginId())).willReturn(Optional.of(user));
+        given(loanHistoryRepository.findAllByUserId(1L)).willReturn(List.of(loanHistory));
+        given(savingHistoryRepository.findAllByUserId(1L)).willReturn(List.of(savingHistory));
+
+        FinanceHistoryResponse response = financeService.getFinanceHistory(user.getLoginId());
+
+        assertThat(response.loans()).hasSize(1);
+        assertThat(response.loans().get(0).historyId()).isEqualTo(1L);
+        assertThat(response.loans().get(0).productName()).isEqualTo("ESG 소액대출");
+        assertThat(response.savings()).hasSize(1);
+        assertThat(response.savings().get(0).historyId()).isEqualTo(2L);
+        assertThat(response.savings().get(0).productName()).isEqualTo("그린 스텝업 적금");
     }
 
     @Test
@@ -199,6 +243,24 @@ class FinanceServiceTest {
         ReflectionTestUtils.setField(userSaving, "maturityDate", LocalDate.of(2027, 4, 1));
         ReflectionTestUtils.setField(userSaving, "joinedAt", LocalDateTime.of(2026, 4, 1, 0, 0));
         return userSaving;
+    }
+
+    private LoanHistory createLoanHistory(UserLoan userLoan, Long id, Long amount, LocalDateTime paymentDate) {
+        LoanHistory loanHistory = newInstance(LoanHistory.class);
+        ReflectionTestUtils.setField(loanHistory, "id", id);
+        ReflectionTestUtils.setField(loanHistory, "userLoan", userLoan);
+        ReflectionTestUtils.setField(loanHistory, "amount", amount);
+        ReflectionTestUtils.setField(loanHistory, "paymentDate", paymentDate);
+        return loanHistory;
+    }
+
+    private SavingHistory createSavingHistory(UserSaving userSaving, Long id, Long amount, LocalDateTime paymentDate) {
+        SavingHistory savingHistory = newInstance(SavingHistory.class);
+        ReflectionTestUtils.setField(savingHistory, "id", id);
+        ReflectionTestUtils.setField(savingHistory, "userSaving", userSaving);
+        ReflectionTestUtils.setField(savingHistory, "amount", amount);
+        ReflectionTestUtils.setField(savingHistory, "paymentDate", paymentDate);
+        return savingHistory;
     }
 
     private <T> T newInstance(Class<T> type) {

--- a/src/test/java/com/shinhan/esg_be/domain/bank/service/FinanceServiceTest.java
+++ b/src/test/java/com/shinhan/esg_be/domain/bank/service/FinanceServiceTest.java
@@ -1,12 +1,16 @@
 package com.shinhan.esg_be.domain.bank.service;
 
+import com.shinhan.esg_be.domain.bank.dto.response.FinanceMyResponse;
 import com.shinhan.esg_be.domain.bank.dto.response.FinanceProductListResponse;
 import com.shinhan.esg_be.domain.bank.entity.FinancialProduct;
 import com.shinhan.esg_be.domain.bank.entity.UserLoan;
+import com.shinhan.esg_be.domain.bank.entity.UserSaving;
 import com.shinhan.esg_be.domain.bank.entity.enums.LoanStatus;
 import com.shinhan.esg_be.domain.bank.entity.enums.ProductType;
+import com.shinhan.esg_be.domain.bank.entity.enums.SavingStatus;
 import com.shinhan.esg_be.domain.bank.repository.FinancialProductRepository;
 import com.shinhan.esg_be.domain.bank.repository.UserLoanRepository;
+import com.shinhan.esg_be.domain.bank.repository.UserSavingRepository;
 import com.shinhan.esg_be.domain.user.entity.User;
 import com.shinhan.esg_be.domain.user.repository.UserRepository;
 import org.junit.jupiter.api.DisplayName;
@@ -40,10 +44,45 @@ class FinanceServiceTest {
     private UserLoanRepository userLoanRepository;
 
     @Mock
+    private UserSavingRepository userSavingRepository;
+
+    @Mock
     private UserRepository userRepository;
 
     @Test
-    @DisplayName("점수 800점 이상 사용자는 대출 상품 조회 시 200만원 한도와 7퍼센트 금리를 받는다")
+    @DisplayName("마이페이지 금융상품 조회는 활성 대출과 적금 정보를 함께 반환한다")
+    void getMyFinance() {
+        User user = createUser("finance-user-my", 100, 500, 100, 100);
+        ReflectionTestUtils.setField(user, "userId", 1L);
+
+        FinancialProduct loanProduct = createFinancialProduct("ESG 소액대출", ProductType.LOAN, "8.50", "8.50", 12);
+        ReflectionTestUtils.setField(loanProduct, "finProductId", 11L);
+        UserLoan userLoan = createUserLoan(user, loanProduct);
+        ReflectionTestUtils.setField(userLoan, "loanId", 101L);
+
+        FinancialProduct savingProduct = createFinancialProduct("그린 스텝업 적금", ProductType.SAVINGS, "2.00", "4.40", 12);
+        ReflectionTestUtils.setField(savingProduct, "finProductId", 22L);
+        UserSaving userSaving = createUserSaving(user, savingProduct);
+        ReflectionTestUtils.setField(userSaving, "savingId", 202L);
+
+        given(userRepository.findByLoginId(user.getLoginId())).willReturn(Optional.of(user));
+        given(userLoanRepository.findByUser_UserIdAndStatus(1L, LoanStatus.ACTIVE)).willReturn(Optional.of(userLoan));
+        given(userSavingRepository.findByUser_UserIdAndStatus(1L, SavingStatus.ACTIVE)).willReturn(Optional.of(userSaving));
+
+        FinanceMyResponse response = financeService.getMyFinance(user.getLoginId());
+
+        assertThat(response.activeLoan()).isNotNull();
+        assertThat(response.activeLoan().loanId()).isEqualTo(101L);
+        assertThat(response.activeLoan().productId()).isEqualTo(11L);
+        assertThat(response.activeLoan().productName()).isEqualTo("ESG 소액대출");
+        assertThat(response.activeSaving()).isNotNull();
+        assertThat(response.activeSaving().savingId()).isEqualTo(202L);
+        assertThat(response.activeSaving().productId()).isEqualTo(22L);
+        assertThat(response.activeSaving().productName()).isEqualTo("그린 스텝업 적금");
+    }
+
+    @Test
+    @DisplayName("점수 800 이상 사용자는 대출 상품 조회 시 200만원 한도와 7.00 금리를 받는다")
     void getLoanProducts() {
         User user = createUser("finance-user-1", 100, 500, 100, 100);
         FinancialProduct product = createFinancialProduct("ESG 소액대출", ProductType.LOAN, "8.50", "8.50", 12);
@@ -63,7 +102,7 @@ class FinanceServiceTest {
     }
 
     @Test
-    @DisplayName("활성 대출이 있으면 대출 상품은 조회되지만 가입 가능 상태는 false다")
+    @DisplayName("활성 대출이 있으면 대출 상품은 조회되지만 신청 가능 상태는 false다")
     void getLoanProductsWithActiveLoan() {
         User user = createUser("finance-user-2", 100, 500, 200, 100);
         FinancialProduct product = createFinancialProduct("ESG 소액대출", ProductType.LOAN, "8.50", "8.50", 12);
@@ -84,7 +123,7 @@ class FinanceServiceTest {
     }
 
     @Test
-    @DisplayName("적금 상품 조회 시 기본 금리와 최대 금리를 그대로 반환한다")
+    @DisplayName("적금 상품 조회는 기본 금리와 최대 금리를 그대로 반환한다")
     void getSavingProducts() {
         User user = createUser("finance-user-3", 50, 250, 100, 100);
         FinancialProduct product = createFinancialProduct("그린 스텝업 적금", ProductType.SAVINGS, "2.00", "4.40", 12);
@@ -147,6 +186,19 @@ class FinanceServiceTest {
         ReflectionTestUtils.setField(userLoan, "baseEsgScore", user.getTotalScore());
         ReflectionTestUtils.setField(userLoan, "createdAt", LocalDateTime.of(2026, 4, 1, 0, 0));
         return userLoan;
+    }
+
+    private UserSaving createUserSaving(User user, FinancialProduct product) {
+        UserSaving userSaving = newInstance(UserSaving.class);
+        ReflectionTestUtils.setField(userSaving, "user", user);
+        ReflectionTestUtils.setField(userSaving, "financialProduct", product);
+        ReflectionTestUtils.setField(userSaving, "monthlyAmount", 300_000L);
+        ReflectionTestUtils.setField(userSaving, "status", SavingStatus.ACTIVE);
+        ReflectionTestUtils.setField(userSaving, "hasPenalty", false);
+        ReflectionTestUtils.setField(userSaving, "score", user.getTotalScore());
+        ReflectionTestUtils.setField(userSaving, "maturityDate", LocalDate.of(2027, 4, 1));
+        ReflectionTestUtils.setField(userSaving, "joinedAt", LocalDateTime.of(2026, 4, 1, 0, 0));
+        return userSaving;
     }
 
     private <T> T newInstance(Class<T> type) {


### PR DESCRIPTION
## 🔗 관련 이슈
Closes #42

## 📌 작업 내용
- 금융 마이페이지 조회 API를 추가했습니다.
- 금융 이력 조회 API를 추가했습니다.

## 🛠 변경 사항
- `GET /api/v1/finance/my` 엔드포인트를 추가해 활성 대출/적금 정보를 함께 조회할 수 있도록 구현했습니다.
- `GET /api/v1/finance/history` 엔드포인트를 추가해 대출 상환 이력과 적금 납입 이력을 함께 조회할 수 있도록 구현했습니다.
- 마이페이지 조회/이력 조회용 응답 DTO와 서비스 로직을 추가했습니다.
- 금융 이력 조회를 위한 `LoanHistoryRepository`, `SavingHistoryRepository`를 추가했습니다.
- `FinanceControllerTest`, `FinanceServiceTest`에 조회 API 테스트를 추가했습니다.

## ✅ 테스트 결과
- [x] 로컬에서 정상 동작 확인
- [x] API 테스트 완료 (해당되면)
- [x] 빌드 에러 없음
