### PR TITLE
마이페이지 포인트 관리 조회 API 구현

### DIFF
--- a/src/main/java/com/shinhan/esg_be/domain/point/controller/MyPointController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/controller/MyPointController.java
@@ -1,0 +1,30 @@
+package com.shinhan.esg_be.domain.point.controller;
+
+import com.shinhan.esg_be.domain.point.dto.response.MyPointHistoryResponse;
+import com.shinhan.esg_be.domain.point.dto.response.MyPointSummaryResponse;
+import com.shinhan.esg_be.domain.point.service.MyPointService;
+import com.shinhan.esg_be.global.security.AuthContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/my/points")
+@RequiredArgsConstructor
+public class MyPointController {
+
+    private final MyPointService myPointService;
+    private final AuthContext authContext;
+
+    @GetMapping("/summary")
+    public ResponseEntity<MyPointSummaryResponse> getSummary() {
+        return ResponseEntity.ok(myPointService.getSummary(authContext.currentUserId()));
+    }
+
+    @GetMapping("/histories")
+    public ResponseEntity<MyPointHistoryResponse> getHistories() {
+        return ResponseEntity.ok(myPointService.getHistories(authContext.currentUserId()));
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/dto/response/MyPointHistoryItemResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/dto/response/MyPointHistoryItemResponse.java
@@ -1,0 +1,19 @@
+package com.shinhan.esg_be.domain.point.dto.response;
+
+import com.shinhan.esg_be.domain.point.entity.enums.PointReason;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+public class MyPointHistoryItemResponse {
+
+    private final Long userPointId;
+    private final String title;
+    private final PointReason reason;
+    private final Long changedAmount;
+    private final Long pointAfter;
+    private final LocalDateTime createdAt;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/dto/response/MyPointHistoryResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/dto/response/MyPointHistoryResponse.java
@@ -1,0 +1,13 @@
+package com.shinhan.esg_be.domain.point.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class MyPointHistoryResponse {
+
+    private final List<MyPointHistoryItemResponse> histories;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/dto/response/MyPointSummaryResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/dto/response/MyPointSummaryResponse.java
@@ -1,0 +1,12 @@
+package com.shinhan.esg_be.domain.point.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class MyPointSummaryResponse {
+
+    private final Long userId;
+    private final Long totalPoints;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/point/repository/UserPointRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/repository/UserPointRepository.java
@@ -28,6 +28,19 @@ public interface UserPointRepository extends JpaRepository<UserPoint, Long> {
             @Param("reason") PointReason reason
     );
 
+    @Query("""
+            select up
+            from UserPoint up
+            left join fetch up.item i
+            where up.user.userId = :userId
+              and up.createdAt >= :startDateTime
+            order by up.createdAt desc
+            """)
+    List<UserPoint> findPointHistoriesByUserIdAndStartDateTime(
+            @Param("userId") Long userId,
+            @Param("startDateTime") LocalDateTime startDateTime
+    );
+
     long countByUserAndReason(User user, PointReason reason);
 
     boolean existsByUserAndReasonAndCreatedAtBetween(

--- a/src/main/java/com/shinhan/esg_be/domain/point/service/MyPointService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/point/service/MyPointService.java
@@ -1,0 +1,87 @@
+package com.shinhan.esg_be.domain.point.service;
+
+import com.shinhan.esg_be.domain.point.dto.response.MyPointHistoryItemResponse;
+import com.shinhan.esg_be.domain.point.dto.response.MyPointHistoryResponse;
+import com.shinhan.esg_be.domain.point.dto.response.MyPointSummaryResponse;
+import com.shinhan.esg_be.domain.point.entity.UserPoint;
+import com.shinhan.esg_be.domain.point.entity.enums.PointReason;
+import com.shinhan.esg_be.domain.point.repository.UserPointRepository;
+import com.shinhan.esg_be.domain.user.entity.User;
+import com.shinhan.esg_be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyPointService {
+
+    private final UserRepository userRepository;
+    private final UserPointRepository userPointRepository;
+    private final Clock clock;
+
+    public MyPointSummaryResponse getSummary(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "사용자 정보를 찾을 수 없습니다."));
+
+        return new MyPointSummaryResponse(
+                user.getUserId(),
+                user.getTotalPoints().longValue()
+        );
+    }
+
+    public MyPointHistoryResponse getHistories(Long userId) {
+        LocalDateTime startDateTime = LocalDateTime.now(clock).minusDays(30);
+
+        List<MyPointHistoryItemResponse> histories = userPointRepository
+                .findPointHistoriesByUserIdAndStartDateTime(userId, startDateTime)
+                .stream()
+                .map(this::toHistoryResponse)
+                .toList();
+
+        return new MyPointHistoryResponse(histories);
+    }
+
+    private MyPointHistoryItemResponse toHistoryResponse(UserPoint userPoint) {
+        return new MyPointHistoryItemResponse(
+                userPoint.getExchangeId(),
+                resolveTitle(userPoint),
+                userPoint.getReason(),
+                userPoint.getChangedAmount(),
+                userPoint.getPointAfter(),
+                userPoint.getCreatedAt()
+        );
+    }
+
+    private String resolveTitle(UserPoint userPoint) {
+        return switch (userPoint.getReason()) {
+            case DONATION -> "기부 참여";
+            case VOLUNTEER -> "봉사 활동 참여";
+            case VOLUNTEER_MILESTONE_BONUS -> "봉사 마일스톤 달성";
+            case PURCHASE -> "친환경 제품 구매";
+            case PHOTO -> "친환경 인증 참여";
+            case PHOTO_STREAK_BONUS -> "친환경 인증 연속 참여";
+            case QUIZ_CORRECT -> "오늘의 퀴즈 정답";
+            case QUIZ_WRONG -> "오늘의 퀴즈 참여";
+            case QUIZ_MONTHLY_BONUS -> "퀴즈 월간 보너스";
+            case ABUSE_RECLAIM -> "부정 적립 회수";
+            case EXCHANGE -> resolveExchangeTitle(userPoint);
+        };
+    }
+
+    private String resolveExchangeTitle(UserPoint userPoint) {
+        if (userPoint.getItem() == null) {
+            return "상품 교환";
+        }
+
+        return userPoint.getItem().getName();
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #49

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- 마이페이지 포인트 관리 화면에서 사용할 포인트 요약 및 내역 조회 API 추가
- 최근 30일 기준으로 포인트 적립/사용 내역을 조회할 수 있도록 구현

## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->
- point 도메인에 MyPointController, MyPointService, 마이페이지 전용 response DTO 추가
- UserPointRepository에 사용자별 포인트 내역 조회 메서드 추가, 최근 30일 조건으로 조회

## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [x] 로컬에서 정상 동작 확인
- [x] API 테스트 완료 (해당되면)
- [x] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
