### PR TITLE
[FEAT] 46 상품관 포트원 결제 준비검증 api 추가

### DIFF
--- a/src/main/java/com/shinhan/esg_be/domain/social/controller/PaymentController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/controller/PaymentController.java
@@ -2,10 +2,13 @@ package com.shinhan.esg_be.domain.social.controller;
 
 import com.shinhan.esg_be.domain.social.dto.request.PaymentPrepareRequest;
 import com.shinhan.esg_be.domain.social.dto.request.PaymentVerifyRequest;
+import com.shinhan.esg_be.domain.social.dto.request.ProductPaymentPrepareRequest;
 import com.shinhan.esg_be.domain.social.dto.response.PaymentPrepareResponse;
 import com.shinhan.esg_be.domain.social.dto.response.PaymentVerifyResponse;
+import com.shinhan.esg_be.domain.social.dto.response.ProductPaymentPrepareResponse;
 import com.shinhan.esg_be.domain.social.service.PaymentPrepareService;
 import com.shinhan.esg_be.domain.social.service.PaymentVerifyService;
+import com.shinhan.esg_be.domain.social.service.ProductPaymentPrepareService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -22,10 +25,18 @@ public class PaymentController {
 
     private final PaymentPrepareService paymentPrepareService;
     private final PaymentVerifyService paymentVerifyService;
+    private final ProductPaymentPrepareService productPaymentPrepareService;
 
     @PostMapping("/prepare")
     public ResponseEntity<PaymentPrepareResponse> preparePayment(@RequestBody @Valid PaymentPrepareRequest request) {
         return ResponseEntity.status(HttpStatus.CREATED).body(paymentPrepareService.preparePayment(request));
+    }
+
+    @PostMapping("/products/prepare")
+    public ResponseEntity<ProductPaymentPrepareResponse> prepareProductPayment(
+            @RequestBody @Valid ProductPaymentPrepareRequest request
+    ) {
+        return ResponseEntity.status(HttpStatus.CREATED).body(productPaymentPrepareService.preparePayment(request));
     }
 
     @PostMapping("/verify")

--- a/src/main/java/com/shinhan/esg_be/domain/social/controller/PaymentController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/controller/PaymentController.java
@@ -3,12 +3,15 @@ package com.shinhan.esg_be.domain.social.controller;
 import com.shinhan.esg_be.domain.social.dto.request.PaymentPrepareRequest;
 import com.shinhan.esg_be.domain.social.dto.request.PaymentVerifyRequest;
 import com.shinhan.esg_be.domain.social.dto.request.ProductPaymentPrepareRequest;
+import com.shinhan.esg_be.domain.social.dto.request.ProductPaymentVerifyRequest;
 import com.shinhan.esg_be.domain.social.dto.response.PaymentPrepareResponse;
 import com.shinhan.esg_be.domain.social.dto.response.PaymentVerifyResponse;
 import com.shinhan.esg_be.domain.social.dto.response.ProductPaymentPrepareResponse;
+import com.shinhan.esg_be.domain.social.dto.response.ProductPaymentVerifyResponse;
 import com.shinhan.esg_be.domain.social.service.PaymentPrepareService;
 import com.shinhan.esg_be.domain.social.service.PaymentVerifyService;
 import com.shinhan.esg_be.domain.social.service.ProductPaymentPrepareService;
+import com.shinhan.esg_be.domain.social.service.ProductPaymentVerifyService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -26,6 +29,7 @@ public class PaymentController {
     private final PaymentPrepareService paymentPrepareService;
     private final PaymentVerifyService paymentVerifyService;
     private final ProductPaymentPrepareService productPaymentPrepareService;
+    private final ProductPaymentVerifyService productPaymentVerifyService;
 
     @PostMapping("/prepare")
     public ResponseEntity<PaymentPrepareResponse> preparePayment(@RequestBody @Valid PaymentPrepareRequest request) {
@@ -42,5 +46,12 @@ public class PaymentController {
     @PostMapping("/verify")
     public ResponseEntity<PaymentVerifyResponse> verifyPayment(@RequestBody @Valid PaymentVerifyRequest request) {
         return ResponseEntity.ok(paymentVerifyService.verifyDonationPayment(request));
+    }
+
+    @PostMapping("/products/verify")
+    public ResponseEntity<ProductPaymentVerifyResponse> verifyProductPayment(
+            @RequestBody @Valid ProductPaymentVerifyRequest request
+    ) {
+        return ResponseEntity.ok(productPaymentVerifyService.verifyProductPayment(request));
     }
 }

--- a/src/main/java/com/shinhan/esg_be/domain/social/dto/request/ProductPaymentPrepareRequest.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/dto/request/ProductPaymentPrepareRequest.java
@@ -1,0 +1,13 @@
+package com.shinhan.esg_be.domain.social.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class ProductPaymentPrepareRequest {
+
+    @NotNull
+    private Long productId;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/dto/request/ProductPaymentVerifyRequest.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/dto/request/ProductPaymentVerifyRequest.java
@@ -1,0 +1,30 @@
+package com.shinhan.esg_be.domain.social.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+public class ProductPaymentVerifyRequest {
+
+    @NotNull
+    private Long productId;
+
+    @NotBlank
+    private String impUid;
+
+    @NotBlank
+    private String merchantUid;
+
+    public Long getProductId() {
+        return productId;
+    }
+
+    public String getImpUid() {
+        return impUid;
+    }
+
+    public String getMerchantUid() {
+        return merchantUid;
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/dto/response/EcoProductDetailResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/dto/response/EcoProductDetailResponse.java
@@ -7,6 +7,7 @@ public class EcoProductDetailResponse {
 
     private final Long productId;
     private final String name;
+    private final String storeName;
     private final String category;
     private final Long price;
     private final String imageUrl;
@@ -17,6 +18,7 @@ public class EcoProductDetailResponse {
     public EcoProductDetailResponse(
             Long productId,
             String name,
+            String storeName,
             String category,
             Long price,
             String imageUrl,
@@ -25,6 +27,7 @@ public class EcoProductDetailResponse {
     ) {
         this.productId = productId;
         this.name = name;
+        this.storeName = storeName;
         this.category = category;
         this.price = price;
         this.imageUrl = imageUrl;

--- a/src/main/java/com/shinhan/esg_be/domain/social/dto/response/EcoProductItemResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/dto/response/EcoProductItemResponse.java
@@ -7,6 +7,7 @@ public class EcoProductItemResponse {
 
     private final Long productId;
     private final String name;
+    private final String storeName;
     private final String category;
     private final Long price;
     private final String imageUrl;
@@ -17,6 +18,7 @@ public class EcoProductItemResponse {
     public EcoProductItemResponse(
             Long productId,
             String name,
+            String storeName,
             String category,
             Long price,
             String imageUrl,
@@ -25,6 +27,7 @@ public class EcoProductItemResponse {
     ) {
         this.productId = productId;
         this.name = name;
+        this.storeName = storeName;
         this.category = category;
         this.price = price;
         this.imageUrl = imageUrl;

--- a/src/main/java/com/shinhan/esg_be/domain/social/dto/response/ProductPaymentPrepareResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/dto/response/ProductPaymentPrepareResponse.java
@@ -10,5 +10,6 @@ public class ProductPaymentPrepareResponse {
     private final String merchantUid;
     private final Long productId;
     private final String productName;
+    private final String storeName;
     private final Long amount;
 }

--- a/src/main/java/com/shinhan/esg_be/domain/social/dto/response/ProductPaymentPrepareResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/dto/response/ProductPaymentPrepareResponse.java
@@ -1,0 +1,14 @@
+package com.shinhan.esg_be.domain.social.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProductPaymentPrepareResponse {
+
+    private final String merchantUid;
+    private final Long productId;
+    private final String productName;
+    private final Long amount;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/dto/response/ProductPaymentVerifyResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/dto/response/ProductPaymentVerifyResponse.java
@@ -1,0 +1,17 @@
+package com.shinhan.esg_be.domain.social.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+public class ProductPaymentVerifyResponse {
+
+    private final Long paymentId;
+    private final Long productId;
+    private final String productName;
+    private final Long amount;
+    private final String paymentStatus;
+    private final Integer awardedPoint;
+    private final Integer currentPoint;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/dto/response/ProductPaymentVerifyResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/dto/response/ProductPaymentVerifyResponse.java
@@ -10,6 +10,7 @@ public class ProductPaymentVerifyResponse {
     private final Long paymentId;
     private final Long productId;
     private final String productName;
+    private final String storeName;
     private final Long amount;
     private final String paymentStatus;
     private final Integer awardedPoint;

--- a/src/main/java/com/shinhan/esg_be/domain/social/entity/EcoProduct.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/entity/EcoProduct.java
@@ -25,6 +25,9 @@ public class EcoProduct extends BaseTimeEntity {
     @Column(nullable = false)
     private String name;
 
+    @Column(name = "store_name", nullable = false)
+    private String storeName;
+
     @Column(nullable = false)
     private String category;
 

--- a/src/main/java/com/shinhan/esg_be/domain/social/entity/UserEcoProduct.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/entity/UserEcoProduct.java
@@ -46,4 +46,12 @@ public class UserEcoProduct {
     @CreatedDate
     @Column(name = "created_at", nullable = false, updatable = false)
     private LocalDateTime createdAt;
+
+    public static UserEcoProduct create(Payment payment, EcoProduct ecoProduct, User user) {
+        UserEcoProduct userEcoProduct = new UserEcoProduct();
+        userEcoProduct.payment = payment;
+        userEcoProduct.ecoProduct = ecoProduct;
+        userEcoProduct.user = user;
+        return userEcoProduct;
+    }
 }

--- a/src/main/java/com/shinhan/esg_be/domain/social/repository/EcoProductRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/repository/EcoProductRepository.java
@@ -14,6 +14,7 @@ public interface EcoProductRepository extends JpaRepository<EcoProduct, Long> {
 
     List<EcoProduct> findByIsActiveTrue();
     List<EcoProduct> findByIsActiveTrueAndStockGreaterThan(Integer stock);
+    Optional<EcoProduct> findByProductIdAndIsActiveTrue(Long productId);
 
     @Query("""
             select new com.shinhan.esg_be.domain.social.dto.response.EcoProductItemResponse(

--- a/src/main/java/com/shinhan/esg_be/domain/social/repository/EcoProductRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/repository/EcoProductRepository.java
@@ -21,6 +21,7 @@ public interface EcoProductRepository extends JpaRepository<EcoProduct, Long> {
             select new com.shinhan.esg_be.domain.social.dto.response.EcoProductItemResponse(
                 e.productId,
                 e.name,
+                e.storeName,
                 e.category,
                 e.price,
                 e.imageUrl,
@@ -37,6 +38,7 @@ public interface EcoProductRepository extends JpaRepository<EcoProduct, Long> {
             select new com.shinhan.esg_be.domain.social.dto.response.EcoProductDetailResponse(
                 e.productId,
                 e.name,
+                e.storeName,
                 e.category,
                 e.price,
                 e.imageUrl,

--- a/src/main/java/com/shinhan/esg_be/domain/social/repository/EcoProductRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/repository/EcoProductRepository.java
@@ -4,6 +4,7 @@ import com.shinhan.esg_be.domain.social.dto.response.EcoProductDetailResponse;
 import com.shinhan.esg_be.domain.social.dto.response.EcoProductItemResponse;
 import com.shinhan.esg_be.domain.social.entity.EcoProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -47,4 +48,13 @@ public interface EcoProductRepository extends JpaRepository<EcoProduct, Long> {
               and e.isActive = true
             """)
     Optional<EcoProductDetailResponse> findActiveProductDetail(@Param("productId") Long productId);
+
+    @Modifying(clearAutomatically = true, flushAutomatically = true)
+    @Query("""
+            update EcoProduct e
+            set e.stock = e.stock - 1
+            where e.productId = :productId
+              and e.stock > 0
+            """)
+    int decreaseStock(@Param("productId") Long productId);
 }

--- a/src/main/java/com/shinhan/esg_be/domain/social/service/ProductPaymentPrepareService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/service/ProductPaymentPrepareService.java
@@ -1,0 +1,43 @@
+package com.shinhan.esg_be.domain.social.service;
+
+import com.shinhan.esg_be.domain.social.dto.request.ProductPaymentPrepareRequest;
+import com.shinhan.esg_be.domain.social.dto.response.ProductPaymentPrepareResponse;
+import com.shinhan.esg_be.domain.social.entity.EcoProduct;
+import com.shinhan.esg_be.domain.social.repository.EcoProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.util.UUID;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ProductPaymentPrepareService {
+
+    private final EcoProductRepository ecoProductRepository;
+
+    public ProductPaymentPrepareResponse preparePayment(ProductPaymentPrepareRequest request) {
+        EcoProduct product = ecoProductRepository.findByProductIdAndIsActiveTrue(request.getProductId())
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "상품을 찾을 수 없습니다."));
+
+        if (product.getStock() == null || product.getStock() <= 0) {
+            throw new ResponseStatusException(BAD_REQUEST, "품절된 상품은 결제할 수 없습니다.");
+        }
+
+        return new ProductPaymentPrepareResponse(
+                createMerchantUid(),
+                product.getProductId(),
+                product.getName(),
+                product.getPrice()
+        );
+    }
+
+    private String createMerchantUid() {
+        return "PRODUCT-" + UUID.randomUUID();
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/social/service/ProductPaymentPrepareService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/service/ProductPaymentPrepareService.java
@@ -33,6 +33,7 @@ public class ProductPaymentPrepareService {
                 createMerchantUid(),
                 product.getProductId(),
                 product.getName(),
+                product.getStoreName(),
                 product.getPrice()
         );
     }

--- a/src/main/java/com/shinhan/esg_be/domain/social/service/ProductPaymentVerifyService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/service/ProductPaymentVerifyService.java
@@ -112,6 +112,7 @@ public class ProductPaymentVerifyService {
                 payment.getPaymentId(),
                 product.getProductId(),
                 product.getName(),
+                product.getStoreName(),
                 payment.getAmount(),
                 payment.getPaymentStatus(),
                 pointResult.activityPoint() + pointResult.bonusPoint(),

--- a/src/main/java/com/shinhan/esg_be/domain/social/service/ProductPaymentVerifyService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/social/service/ProductPaymentVerifyService.java
@@ -1,0 +1,121 @@
+package com.shinhan.esg_be.domain.social.service;
+
+import com.shinhan.esg_be.domain.point.service.result.ApplyActivityPointResult;
+import com.shinhan.esg_be.domain.reward.service.RewardService;
+import com.shinhan.esg_be.domain.reward.service.command.ApplyActivityRewardCommand;
+import com.shinhan.esg_be.domain.reward.service.result.ApplyActivityRewardResult;
+import com.shinhan.esg_be.domain.social.dto.request.ProductPaymentVerifyRequest;
+import com.shinhan.esg_be.domain.social.dto.response.ProductPaymentVerifyResponse;
+import com.shinhan.esg_be.domain.social.entity.EcoProduct;
+import com.shinhan.esg_be.domain.social.entity.Payment;
+import com.shinhan.esg_be.domain.social.entity.UserEcoProduct;
+import com.shinhan.esg_be.domain.social.repository.EcoProductRepository;
+import com.shinhan.esg_be.domain.social.repository.PaymentRepository;
+import com.shinhan.esg_be.domain.social.repository.UserEcoProductRepository;
+import com.shinhan.esg_be.domain.user.entity.User;
+import com.shinhan.esg_be.domain.user.repository.UserRepository;
+import com.shinhan.esg_be.global.common.enums.ActivityType;
+import com.shinhan.esg_be.global.exception.BadRequestException;
+import com.shinhan.esg_be.global.security.AuthContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ProductPaymentVerifyService {
+
+    private final AuthContext authContext;
+    private final PortOnePaymentService portOnePaymentService;
+    private final EcoProductRepository ecoProductRepository;
+    private final PaymentRepository paymentRepository;
+    private final UserEcoProductRepository userEcoProductRepository;
+    private final UserRepository userRepository;
+    private final RewardService rewardService;
+
+    public ProductPaymentVerifyResponse verifyProductPayment(ProductPaymentVerifyRequest request) {
+        Long userId = authContext.currentUserId();
+        LocalDateTime activityDateTime = LocalDateTime.now();
+
+        EcoProduct product = ecoProductRepository.findByProductIdAndIsActiveTrue(request.getProductId())
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "상품을 찾을 수 없습니다."));
+
+        if (product.getStock() == null || product.getStock() <= 0) {
+            throw new ResponseStatusException(BAD_REQUEST, "품절된 상품은 결제할 수 없습니다.");
+        }
+
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "사용자를 찾을 수 없습니다."));
+
+        if (paymentRepository.existsByImpUid(request.getImpUid())) {
+            throw new BadRequestException("이미 처리된 결제입니다.");
+        }
+        if (paymentRepository.existsByMerchantId(request.getMerchantUid())) {
+            throw new BadRequestException("이미 사용된 merchantUid입니다.");
+        }
+
+        PortOnePaymentService.VerifiedPayment verifiedPayment =
+                portOnePaymentService.verify(request.getImpUid());
+
+        if (!request.getMerchantUid().equals(verifiedPayment.merchantUid())) {
+            throw new BadRequestException("merchantUid가 일치하지 않습니다.");
+        }
+        if (!product.getPrice().equals(verifiedPayment.amount())) {
+            throw new BadRequestException("상품 결제 금액이 일치하지 않습니다.");
+        }
+
+        Payment payment = paymentRepository.save(Payment.create(
+                verifiedPayment.impUid(),
+                verifiedPayment.merchantUid(),
+                verifiedPayment.amount(),
+                verifiedPayment.paymentMethod(),
+                verifiedPayment.paymentStatus(),
+                verifiedPayment.paidAt(),
+                verifiedPayment.failedReason(),
+                verifiedPayment.buyerName(),
+                verifiedPayment.buyerEmail(),
+                verifiedPayment.buyerTel(),
+                verifiedPayment.pgProvider(),
+                verifiedPayment.pgTid(),
+                verifiedPayment.cardName(),
+                verifiedPayment.cardNumber(),
+                verifiedPayment.receiptUrl()
+        ));
+
+        int updatedRows = ecoProductRepository.decreaseStock(product.getProductId());
+        if (updatedRows == 0) {
+            throw new ResponseStatusException(BAD_REQUEST, "재고가 부족하여 결제를 완료할 수 없습니다.");
+        }
+
+        userEcoProductRepository.save(UserEcoProduct.create(payment, product, user));
+
+        ApplyActivityRewardResult rewardResult = rewardService.applyActivityReward(
+                new ApplyActivityRewardCommand(
+                        userId,
+                        ActivityType.PURCHASE,
+                        BigDecimal.valueOf(payment.getAmount()),
+                        activityDateTime
+                )
+        );
+
+        ApplyActivityPointResult pointResult = rewardResult.pointResult();
+
+        return new ProductPaymentVerifyResponse(
+                payment.getPaymentId(),
+                product.getProductId(),
+                product.getName(),
+                payment.getAmount(),
+                payment.getPaymentStatus(),
+                pointResult.activityPoint() + pointResult.bonusPoint(),
+                pointResult.pointAfter()
+        );
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/user/dto/response/UserMeResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/user/dto/response/UserMeResponse.java
@@ -12,6 +12,7 @@ public class UserMeResponse {
 
     private String loginId;
     private String name;
+    private String phoneNumber;
     private UserType userType;
     private Grade currentGrade;
     private String message;
@@ -20,6 +21,7 @@ public class UserMeResponse {
         return new UserMeResponse(
                 user.getLoginId(),
                 user.getName(),
+                user.getPhoneNumber(),
                 user.getUserType(),
                 user.getCurrentGrade(),
                 "인증된 사용자 정보를 조회했습니다."


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #46 

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- 상품 결제 준비 API와 결제 검증 API를 구현했습니다. 
- 포트원 결제 이후 결제 정보 저장, 구매 이력 저장, 재고 차감, 포인트 보상 반영까지 연결했습니다. 
- 상품 기업명 표시를 위해 eco_product에 store_name 컬럼을 추가했습니다.
- 상품 목록, 상세, 결제 응답에 기업명 정보를 추가했습니다. 
- 기존 사용자 정보 조회 응답에 전화번호를 추가해 결제 화면에서 배송지 정보로 활용할 수 있도록 했습니다.


## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->
- EcoProduct 엔티티에 기업명 저장용 storeName 컬럼을 추가했습니다.
- PaymentController에 상품 결제 준비/검증 엔드포인트를 추가했습니다. 
- ProductPaymentPrepareService, ProductPaymentVerifyService를 추가해 상품 결제 흐름을 구현했습니다. 
- ProductPaymentPrepareRequest/Response, ProductPaymentVerifyRequest/Response DTO를 추가했습니다. 
- EcoProductRepository에 상품 단건 조회와 재고 차감 로직을 추가했습니다. UserEcoProduct에 구매 이력 생성 로직을 추가했습니다. 
- 상품 결제 검증 성공 시 payment 저장, user_eco_product 저장, 재고 차감, RewardService.applyActivityReward(...PURCHASE...) 호출이 함께 처리되도록 구현했습니다. 
- EcoProductItemResponse, EcoProductDetailResponse, 상품 결제 응답에 storeName을 포함하도록 확장했습니다. 기존 /api/users/me 응답에 phoneNumber를 추가했습니다.

## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [ ] 로컬에서 정상 동작 확인
- [ ] API 테스트 완료 (해당되면)
- [ ] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
