### PR TITLE
52 feat 마이페이지   프로필 및 계정 관리 기능 구현

### DIFF
--- a/src/main/java/com/shinhan/esg_be/domain/auth/dto/internal/VerifiedIdentityDetails.java
+++ b/src/main/java/com/shinhan/esg_be/domain/auth/dto/internal/VerifiedIdentityDetails.java
@@ -1,0 +1,15 @@
+package com.shinhan.esg_be.domain.auth.dto.internal;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+// 본인인증 결과에서 번호 변경에 필요한 값을 담는 DTO
+public class VerifiedIdentityDetails {
+
+    private final String ciDi;
+    private final String name;
+    private final String phoneNumber;
+    private final String birthdate;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/auth/dto/response/IdentityVerificationResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/auth/dto/response/IdentityVerificationResponse.java
@@ -9,4 +9,5 @@ public class IdentityVerificationResponse {
 
     private boolean verified;
     private String verificationToken;
+    private String preservedLoginId;
 }

--- a/src/main/java/com/shinhan/esg_be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/auth/service/AuthService.java
@@ -42,37 +42,74 @@ public class AuthService {
     @Transactional
     public void join(AuthJoinRequest req) {
         VerifiedIdentity verifiedIdentity = getVerifiedIdentity(req.getVerificationToken());
-        validateJoinRequest(req, verifiedIdentity.getCiDi());
+        User existingUser = userRepository.findByCiDi(verifiedIdentity.getCiDi()).orElse(null);
+        String loginId = existingUser != null ? existingUser.getLoginId() : req.getLoginId();
 
-        User user = User.create(
-                req.getLoginId(),
-                passwordEncoder.encode(req.getPassword()),
-                req.getName(),
-                req.getEmail(),
-                req.getPhoneNumber().trim(),
-                req.getBirthdate(),
-                verifiedIdentity.getCiDi()
+        if (existingUser != null && Boolean.TRUE.equals(existingUser.getIsActive())) {
+            throw new BadRequestException("이미 가입된 본인 인증 정보입니다.");
+        }
+
+        validateJoinRequest(
+                req,
+                verifiedIdentity.getCiDi(),
+                existingUser == null ? null : existingUser.getUserId(),
+                loginId
         );
 
-        userRepository.save(user);
+        if (existingUser != null) {
+            existingUser.reactivate(
+                    loginId,
+                    passwordEncoder.encode(req.getPassword()),
+                    req.getName(),
+                    req.getEmail(),
+                    req.getPhoneNumber().trim(),
+                    req.getBirthdate(),
+                    verifiedIdentity.getCiDi()
+            );
+        } else {
+            User user = User.create(
+                    loginId,
+                    passwordEncoder.encode(req.getPassword()),
+                    req.getName(),
+                    req.getEmail(),
+                    req.getPhoneNumber().trim(),
+                    req.getBirthdate(),
+                    verifiedIdentity.getCiDi()
+            );
+
+            userRepository.save(user);
+        }
+
         redisTemplate.delete(getVerifiedIdentityKey(req.getVerificationToken()));
     }
 
     @Transactional
     public IdentityVerificationResponse verifyIdentity(String impUid) {
         VerifiedIdentity verifiedIdentity = portOneIdentityVerificationService.verify(impUid);
-        ensureCiDiNotRegistered(verifiedIdentity.getCiDi());
+        User existingUser = userRepository.findByCiDi(verifiedIdentity.getCiDi()).orElse(null);
+
+        if (existingUser != null && Boolean.TRUE.equals(existingUser.getIsActive())) {
+            throw new BadRequestException("이미 가입된 본인 인증 정보입니다.");
+        }
 
         String verificationToken = UUID.randomUUID().toString();
         storeVerifiedIdentity(verificationToken, verifiedIdentity);
 
-        return new IdentityVerificationResponse(true, verificationToken);
+        return new IdentityVerificationResponse(
+                true,
+                verificationToken,
+                existingUser != null ? existingUser.getLoginId() : null
+        );
     }
 
     @Transactional
     public TokenResponse login(AuthLoginRequest req) {
         User user = userRepository.findByLoginId(req.getLoginId())
                 .orElseThrow(() -> new BadRequestException("사용자를 찾을 수 없습니다."));
+
+        if (!Boolean.TRUE.equals(user.getIsActive())) {
+            throw new BadRequestException("탈퇴한 계정은 로그인할 수 없습니다.");
+        }
 
         if (!passwordEncoder.matches(req.getPassword(), user.getPassword())) {
             throw new BadRequestException("비밀번호가 일치하지 않습니다.");
@@ -84,13 +121,19 @@ public class AuthService {
     @Transactional
     public TokenResponse reissue(String refreshToken) {
         TokenSubject tokenSubject = validateRefreshToken(refreshToken);
+        User user = userRepository.findByLoginId(tokenSubject.loginId())
+                .orElseThrow(() -> new BadRequestException("사용자를 찾을 수 없습니다."));
         String savedRefreshToken = redisTemplate.opsForValue().get(getRefreshTokenKey(tokenSubject.loginId()));
+
+        if (!Boolean.TRUE.equals(user.getIsActive())) {
+            throw new BadRequestException("탈퇴한 계정은 로그인할 수 없습니다.");
+        }
 
         if (savedRefreshToken == null || !savedRefreshToken.equals(refreshToken)) {
             throw new BadRequestException("저장된 리프레시 토큰과 일치하지 않습니다.");
         }
 
-        return issueTokenPair(tokenSubject.userId(), tokenSubject.loginId());
+        return issueTokenPair(user.getUserId(), user.getLoginId());
     }
 
     @Transactional
@@ -103,17 +146,35 @@ public class AuthService {
         return userRepository.existsByLoginId(loginId);
     }
 
-    private void validateJoinRequest(AuthJoinRequest req, String ciDi) {
-        if (userRepository.existsByLoginId(req.getLoginId())) {
+    private void validateJoinRequest(AuthJoinRequest req, String ciDi, Long excludeUserId, String loginId) {
+        String phoneNumber = req.getPhoneNumber().trim();
+
+        if (excludeUserId == null) {
+            if (userRepository.existsByLoginId(loginId)) {
+                throw new BadRequestException("이미 존재하는 아이디입니다.");
+            }
+            if (userRepository.existsByEmail(req.getEmail())) {
+                throw new BadRequestException("이미 사용 중인 이메일입니다.");
+            }
+            if (userRepository.existsByPhoneNumber(phoneNumber)) {
+                throw new BadRequestException("이미 등록된 전화번호입니다.");
+            }
+            ensureCiDiNotRegistered(ciDi);
+            return;
+        }
+
+        if (userRepository.existsByLoginIdAndUserIdNot(loginId, excludeUserId)) {
             throw new BadRequestException("이미 존재하는 아이디입니다.");
         }
-        if (userRepository.existsByEmail(req.getEmail())) {
+        if (userRepository.existsByEmailAndUserIdNot(req.getEmail(), excludeUserId)) {
             throw new BadRequestException("이미 사용 중인 이메일입니다.");
         }
-        if (userRepository.existsByPhoneNumber(req.getPhoneNumber().trim())) {
+        if (userRepository.existsByPhoneNumberAndUserIdNot(phoneNumber, excludeUserId)) {
             throw new BadRequestException("이미 등록된 전화번호입니다.");
         }
-        ensureCiDiNotRegistered(ciDi);
+        if (userRepository.existsByCiDiAndUserIdNot(ciDi, excludeUserId)) {
+            throw new BadRequestException("이미 가입된 본인 인증 정보입니다.");
+        }
     }
 
     private void ensureCiDiNotRegistered(String ciDi) {

--- a/src/main/java/com/shinhan/esg_be/domain/auth/service/PortOneIdentityVerificationService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/auth/service/PortOneIdentityVerificationService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.shinhan.esg_be.domain.auth.dto.internal.VerifiedIdentity;
+import com.shinhan.esg_be.domain.auth.dto.internal.VerifiedIdentityDetails;
 import com.shinhan.esg_be.global.config.PortOneProperties;
 import com.shinhan.esg_be.global.exception.BadRequestException;
 import lombok.RequiredArgsConstructor;
@@ -33,6 +34,12 @@ public class PortOneIdentityVerificationService {
     private final PortOneProperties portOneProperties;
 
     public VerifiedIdentity verify(String impUid) {
+        VerifiedIdentityDetails verifiedIdentityDetails = verifyDetails(impUid);
+        return new VerifiedIdentity(verifiedIdentityDetails.getCiDi());
+    }
+
+    // 번호 변경에 필요한 본인인증 상세 정보를 조회
+    public VerifiedIdentityDetails verifyDetails(String impUid) {
         if (!hasText(impUid)) {
             throw new BadRequestException("impUid가 비어 있습니다.");
         }
@@ -66,10 +73,9 @@ public class PortOneIdentityVerificationService {
                 throw new BadRequestException("본인인증이 완료되지 않았습니다.");
             }
 
-            String ciDi = createStableCiDi(data);
             log.info("PortOne verification succeeded impUid={} derivedCiDi=true", impUid);
 
-            return new VerifiedIdentity(ciDi);
+            return buildVerifiedIdentityDetails(data);
         } catch (IOException e) {
             throw new RuntimeException("PortOne 본인인증 응답 파싱에 실패했습니다.", e);
         } catch (InterruptedException e) {
@@ -165,6 +171,20 @@ public class PortOneIdentityVerificationService {
         if (statusCode < 200 || statusCode >= 300) {
             throw new BadRequestException(message + " status=" + statusCode);
         }
+    }
+
+    // 인증된 이름, 번호, 생년월일로 새 ciDi 값 생성
+    private VerifiedIdentityDetails buildVerifiedIdentityDetails(CertificationData data) {
+        String name = requireValue(data.name, "PortOne 이름 정보가 없습니다.");
+        String phoneNumber = normalizePhoneNumber(requireValue(data.phone, "PortOne 전화번호 정보가 없습니다."));
+        String birthdate = requireValue(data.birthday, "PortOne 생년월일 정보가 없습니다.");
+
+        return new VerifiedIdentityDetails(
+                createStableCiDi(data),
+                name,
+                phoneNumber,
+                birthdate
+        );
     }
 
     private String createStableCiDi(CertificationData data) {

--- a/src/main/java/com/shinhan/esg_be/domain/user/controller/MyProfileController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/user/controller/MyProfileController.java
@@ -1,0 +1,87 @@
+package com.shinhan.esg_be.domain.user.controller;
+
+import com.shinhan.esg_be.domain.user.dto.request.CheckMyPasswordRequest;
+import com.shinhan.esg_be.domain.user.dto.request.UpdateMyEmailRequest;
+import com.shinhan.esg_be.domain.user.dto.request.UpdateMyPasswordRequest;
+import com.shinhan.esg_be.domain.user.dto.request.UpdateMyPhoneNumberRequest;
+import com.shinhan.esg_be.domain.user.dto.response.CheckMyPasswordResponse;
+import com.shinhan.esg_be.domain.user.dto.response.MyProfileResponse;
+import com.shinhan.esg_be.domain.user.dto.response.UpdateMyEmailResponse;
+import com.shinhan.esg_be.domain.user.dto.response.UpdateMyPasswordResponse;
+import com.shinhan.esg_be.domain.user.dto.response.UpdateMyPhoneNumberResponse;
+import com.shinhan.esg_be.domain.user.dto.response.WithdrawMyAccountResponse;
+import com.shinhan.esg_be.domain.user.service.MyProfileService;
+import com.shinhan.esg_be.global.security.AuthContext;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/my/profile")
+@RequiredArgsConstructor
+// 마이페이지 프로필 조회 및 수정 API 제공
+public class MyProfileController {
+
+    private final MyProfileService myProfileService;
+    private final AuthContext authContext;
+
+    @GetMapping
+    public ResponseEntity<MyProfileResponse> getMyProfile() {
+        return ResponseEntity.ok(myProfileService.getMyProfile(authContext.currentUserId()));
+    }
+
+    @PostMapping("/password/check")
+    public ResponseEntity<CheckMyPasswordResponse> checkMyPassword(
+            @RequestBody @Valid CheckMyPasswordRequest request
+    ) {
+        return ResponseEntity.ok(
+                myProfileService.checkMyPassword(
+                        authContext.currentUserId(),
+                        request.getCurrentPassword()
+                )
+        );
+    }
+
+    @PatchMapping("/password")
+    public ResponseEntity<UpdateMyPasswordResponse> updateMyPassword(
+            @RequestBody @Valid UpdateMyPasswordRequest request
+    ) {
+        return ResponseEntity.ok(
+                myProfileService.updateMyPassword(
+                        authContext.currentUserId(),
+                        request.getCurrentPassword(),
+                        request.getNewPassword(),
+                        request.getNewPasswordConfirm()
+                )
+        );
+    }
+
+    @PatchMapping("/email")
+    public ResponseEntity<UpdateMyEmailResponse> updateMyEmail(
+            @RequestBody @Valid UpdateMyEmailRequest request
+    ) {
+        return ResponseEntity.ok(
+                myProfileService.updateMyEmail(authContext.currentUserId(), request.getEmail())
+        );
+    }
+
+    @PatchMapping("/phone")
+    public ResponseEntity<UpdateMyPhoneNumberResponse> updateMyPhoneNumber(
+            @RequestBody @Valid UpdateMyPhoneNumberRequest request
+    ) {
+        return ResponseEntity.ok(
+                myProfileService.updateMyPhoneNumber(authContext.currentUserId(), request.getImpUid())
+        );
+    }
+
+    @PatchMapping("/withdraw")
+    public ResponseEntity<WithdrawMyAccountResponse> withdrawMyAccount() {
+        return ResponseEntity.ok(myProfileService.withdrawMyAccount(authContext.currentUserId()));
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/user/dto/request/CheckMyPasswordRequest.java
+++ b/src/main/java/com/shinhan/esg_be/domain/user/dto/request/CheckMyPasswordRequest.java
@@ -1,0 +1,14 @@
+package com.shinhan.esg_be.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+// 현재 비밀번호 확인 시 비밀번호 값을 받는 요청 DTO
+public class CheckMyPasswordRequest {
+
+    @NotBlank(message = "currentPassword는 필수입니다.")
+    private String currentPassword;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/user/dto/request/UpdateMyEmailRequest.java
+++ b/src/main/java/com/shinhan/esg_be/domain/user/dto/request/UpdateMyEmailRequest.java
@@ -1,0 +1,16 @@
+package com.shinhan.esg_be.domain.user.dto.request;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+// 이메일 변경 시 새 이메일을 받는 요청 DTO
+public class UpdateMyEmailRequest {
+
+    @NotBlank(message = "email은 필수입니다.")
+    @Email(message = "올바른 이메일 형식이 아닙니다.")
+    private String email;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/user/dto/request/UpdateMyPasswordRequest.java
+++ b/src/main/java/com/shinhan/esg_be/domain/user/dto/request/UpdateMyPasswordRequest.java
@@ -1,0 +1,20 @@
+package com.shinhan.esg_be.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+// 비밀번호 변경 시 현재/새 비밀번호를 받는 요청 DTO
+public class UpdateMyPasswordRequest {
+
+    @NotBlank(message = "currentPassword는 필수입니다.")
+    private String currentPassword;
+
+    @NotBlank(message = "newPassword는 필수입니다.")
+    private String newPassword;
+
+    @NotBlank(message = "newPasswordConfirm는 필수입니다.")
+    private String newPasswordConfirm;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/user/dto/request/UpdateMyPhoneNumberRequest.java
+++ b/src/main/java/com/shinhan/esg_be/domain/user/dto/request/UpdateMyPhoneNumberRequest.java
@@ -1,0 +1,14 @@
+package com.shinhan.esg_be.domain.user.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+// 휴대폰 번호 변경 시 본인인증 impUid를 받는 요청 DTO
+public class UpdateMyPhoneNumberRequest {
+
+    @NotBlank(message = "impUid는 필수입니다.")
+    private String impUid;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/user/dto/response/CheckMyPasswordResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/user/dto/response/CheckMyPasswordResponse.java
@@ -1,0 +1,13 @@
+package com.shinhan.esg_be.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+// 현재 비밀번호 일치 여부를 내려주는 응답 DTO
+public class CheckMyPasswordResponse {
+
+    private final boolean matched;
+    private final String message;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/user/dto/response/MyProfileResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/user/dto/response/MyProfileResponse.java
@@ -1,0 +1,37 @@
+package com.shinhan.esg_be.domain.user.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.shinhan.esg_be.domain.user.entity.User;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Getter
+@AllArgsConstructor
+// 마이페이지 프로필 화면에 내려줄 응답 DTO
+public class MyProfileResponse {
+
+    private final String loginId;
+    private final String name;
+    private final String email;
+    private final String phoneNumber;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd")
+    private final LocalDate birthdate;
+
+    @JsonFormat(shape = JsonFormat.Shape.STRING, pattern = "yyyy-MM-dd'T'HH:mm:ss")
+    private final LocalDateTime joinedAt;
+
+    public static MyProfileResponse from(User user) {
+        return new MyProfileResponse(
+                user.getLoginId(),
+                user.getName(),
+                user.getEmail(),
+                user.getPhoneNumber(),
+                user.getBirthdate(),
+                user.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/user/dto/response/UpdateMyEmailResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/user/dto/response/UpdateMyEmailResponse.java
@@ -1,0 +1,13 @@
+package com.shinhan.esg_be.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+// 이메일 변경 완료 후 내려주는 응답 DTO
+public class UpdateMyEmailResponse {
+
+    private final String email;
+    private final String message;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/user/dto/response/UpdateMyPasswordResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/user/dto/response/UpdateMyPasswordResponse.java
@@ -1,0 +1,12 @@
+package com.shinhan.esg_be.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+// 비밀번호 변경 완료 메시지를 내려주는 응답 DTO
+public class UpdateMyPasswordResponse {
+
+    private final String message;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/user/dto/response/UpdateMyPhoneNumberResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/user/dto/response/UpdateMyPhoneNumberResponse.java
@@ -1,0 +1,13 @@
+package com.shinhan.esg_be.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+// 휴대폰 번호 변경 완료 후 내려줄 응답 DTO
+public class UpdateMyPhoneNumberResponse {
+
+    private final String phoneNumber;
+    private final String message;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/user/dto/response/WithdrawMyAccountResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/user/dto/response/WithdrawMyAccountResponse.java
@@ -1,0 +1,12 @@
+package com.shinhan.esg_be.domain.user.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@Getter
+@AllArgsConstructor
+// 회원탈퇴 완료 메시지 응답 DTO
+public class WithdrawMyAccountResponse {
+
+    private final String message;
+}

--- a/src/main/java/com/shinhan/esg_be/domain/user/entity/User.java
+++ b/src/main/java/com/shinhan/esg_be/domain/user/entity/User.java
@@ -108,7 +108,28 @@ public class User extends BaseTimeEntity {
 
         return user;
     }
-  
+
+    // 본인인증 후 새 휴대폰 번호와 ciDi를 함께 변경
+    public void updatePhoneNumberAndCiDi(String phoneNumber, String ciDi) {
+        this.phoneNumber = phoneNumber;
+        this.ciDi = ciDi;
+    }
+
+    // 이메일 주소 변경
+    public void updateEmail(String email) {
+        this.email = email;
+    }
+
+    // 암호화된 비밀번호 값으로 변경
+    public void updatePassword(String password) {
+        this.password = password;
+    }
+
+    // 회원탈퇴 시 계정을 비활성 상태로 변경
+    public void withdraw() {
+        this.isActive = false;
+    }
+
     public void applyScore(ScoreCategory scoreCategory, int scoreDelta) {
         if (scoreDelta == 0) {
             return;
@@ -190,5 +211,24 @@ public class User extends BaseTimeEntity {
             return;
         }
         currentGrade = Grade.SEED;
+    }
+
+    public void reactivate(
+            String loginId,
+            String password,
+            String name,
+            String email,
+            String phoneNumber,
+            LocalDate birthdate,
+            String ciDi
+    ) {
+        this.loginId = loginId;
+        this.password = password;
+        this.name = name;
+        this.email = email;
+        this.phoneNumber = phoneNumber;
+        this.birthdate = birthdate;
+        this.ciDi = ciDi;
+        this.isActive = true;
     }
 }

--- a/src/main/java/com/shinhan/esg_be/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/user/repository/UserRepository.java
@@ -15,7 +15,19 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     boolean existsByCiDi(String ciDi);
 
+    // 현재 사용자를 제외하고 같은 ciDi가 있는지 확인
+    boolean existsByCiDiAndUserIdNot(String ciDi, Long userId);
+
     boolean existsByEmail(String email);
 
     boolean existsByPhoneNumber(String phoneNumber);
+
+    // 현재 사용자를 제외하고 같은 전화번호가 있는지 확인
+    boolean existsByPhoneNumberAndUserIdNot(String phoneNumber, Long userId);
+
+    Optional<User> findByCiDi(String ciDi);
+
+    boolean existsByLoginIdAndUserIdNot(String loginId, Long userId);
+
+    boolean existsByEmailAndUserIdNot(String email, Long userId);
 }

--- a/src/main/java/com/shinhan/esg_be/domain/user/service/MyProfileService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/user/service/MyProfileService.java
@@ -1,0 +1,159 @@
+package com.shinhan.esg_be.domain.user.service;
+
+import com.shinhan.esg_be.domain.bank.entity.enums.LoanStatus;
+import com.shinhan.esg_be.domain.bank.entity.enums.SavingStatus;
+import com.shinhan.esg_be.domain.bank.repository.UserLoanRepository;
+import com.shinhan.esg_be.domain.bank.repository.UserSavingRepository;
+import com.shinhan.esg_be.domain.auth.dto.internal.VerifiedIdentityDetails;
+import com.shinhan.esg_be.domain.auth.service.PortOneIdentityVerificationService;
+import com.shinhan.esg_be.domain.user.dto.response.CheckMyPasswordResponse;
+import com.shinhan.esg_be.domain.user.dto.response.MyProfileResponse;
+import com.shinhan.esg_be.domain.user.dto.response.UpdateMyEmailResponse;
+import com.shinhan.esg_be.domain.user.dto.response.UpdateMyPasswordResponse;
+import com.shinhan.esg_be.domain.user.dto.response.UpdateMyPhoneNumberResponse;
+import com.shinhan.esg_be.domain.user.dto.response.WithdrawMyAccountResponse;
+import com.shinhan.esg_be.domain.user.entity.User;
+import com.shinhan.esg_be.domain.user.repository.UserRepository;
+import com.shinhan.esg_be.global.exception.BadRequestException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+// 마이페이지 프로필 조회 및 수정 로직 처리
+public class MyProfileService {
+
+    private final UserRepository userRepository;
+    private final UserSavingRepository userSavingRepository;
+    private final UserLoanRepository userLoanRepository;
+    private final PortOneIdentityVerificationService portOneIdentityVerificationService;
+    private final BCryptPasswordEncoder passwordEncoder;
+
+    public MyProfileResponse getMyProfile(Long userId) {
+        return MyProfileResponse.from(findUser(userId));
+    }
+
+    // 현재 비밀번호 일치 여부 확인
+    public CheckMyPasswordResponse checkMyPassword(Long userId, String currentPassword) {
+        User user = findUser(userId);
+        boolean matched = passwordEncoder.matches(currentPassword, user.getPassword());
+
+        return new CheckMyPasswordResponse(
+                matched,
+                matched ? "현재 비밀번호가 일치합니다." : "현재 비밀번호가 일치하지 않습니다."
+        );
+    }
+
+    @Transactional
+    // 현재 비밀번호 확인 후 새 비밀번호로 변경
+    public UpdateMyPasswordResponse updateMyPassword(
+            Long userId,
+            String currentPassword,
+            String newPassword,
+            String newPasswordConfirm
+    ) {
+        User user = findUser(userId);
+
+        if (!passwordEncoder.matches(currentPassword, user.getPassword())) {
+            throw new BadRequestException("현재 비밀번호가 일치하지 않습니다.");
+        }
+
+        if (!newPassword.equals(newPasswordConfirm)) {
+            throw new BadRequestException("새 비밀번호가 일치하지 않습니다.");
+        }
+
+        user.updatePassword(passwordEncoder.encode(newPassword));
+
+        return new UpdateMyPasswordResponse("비밀번호가 변경되었습니다.");
+    }
+
+    @Transactional
+    // 중복 확인 후 이메일 변경
+    public UpdateMyEmailResponse updateMyEmail(Long userId, String email) {
+        User user = findUser(userId);
+        String trimmedEmail = email == null ? "" : email.trim();
+
+        if (trimmedEmail.equals(user.getEmail())) {
+            return new UpdateMyEmailResponse(
+                    user.getEmail(),
+                    "이메일이 변경되었습니다."
+            );
+        }
+
+        if (userRepository.existsByEmail(trimmedEmail)) {
+            throw new BadRequestException("이미 사용 중인 이메일입니다.");
+        }
+
+        user.updateEmail(trimmedEmail);
+
+        return new UpdateMyEmailResponse(
+                user.getEmail(),
+                "이메일이 변경되었습니다."
+        );
+    }
+
+    @Transactional
+    // 포트원 본인인증 결과로 휴대폰 번호와 ciDi 변경
+    public UpdateMyPhoneNumberResponse updateMyPhoneNumber(Long userId, String impUid) {
+        User user = findUser(userId);
+        VerifiedIdentityDetails verifiedIdentityDetails =
+                portOneIdentityVerificationService.verifyDetails(impUid);
+
+        String formattedPhoneNumber = formatPhoneNumber(verifiedIdentityDetails.getPhoneNumber());
+
+        if (userRepository.existsByPhoneNumberAndUserIdNot(formattedPhoneNumber, userId)) {
+            throw new BadRequestException("이미 등록된 전화번호입니다.");
+        }
+
+        if (userRepository.existsByCiDiAndUserIdNot(verifiedIdentityDetails.getCiDi(), userId)) {
+            throw new BadRequestException("이미 가입된 본인 인증 정보입니다.");
+        }
+
+        user.updatePhoneNumberAndCiDi(formattedPhoneNumber, verifiedIdentityDetails.getCiDi());
+
+        return new UpdateMyPhoneNumberResponse(
+                user.getPhoneNumber(),
+                "휴대폰 번호가 변경되었습니다."
+        );
+    }
+
+    @Transactional
+    // 활성 대출·적금이 없을 때만 회원탈퇴 처리
+    public WithdrawMyAccountResponse withdrawMyAccount(Long userId) {
+        User user = findUser(userId);
+
+        if (userSavingRepository.findByUser_UserIdAndStatus(userId, SavingStatus.ACTIVE).isPresent()) {
+            throw new BadRequestException("적금 상품을 보유하고 있어 회원탈퇴가 불가능합니다.");
+        }
+
+        if (userLoanRepository.findByUser_UserIdAndStatus(userId, LoanStatus.ACTIVE).isPresent()) {
+            throw new BadRequestException("대출 상품을 보유하고 있어 회원탈퇴가 불가능합니다.");
+        }
+
+        user.withdraw();
+
+        return new WithdrawMyAccountResponse("회원탈퇴가 완료되었습니다.");
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new BadRequestException("사용자를 찾을 수 없습니다."));
+    }
+
+    private String formatPhoneNumber(String phoneNumber) {
+        String digitsOnly = phoneNumber == null ? "" : phoneNumber.replaceAll("[^0-9]", "");
+
+        if (digitsOnly.length() != 11) {
+            throw new BadRequestException("본인인증 결과에서 유효한 휴대폰 번호를 찾을 수 없습니다.");
+        }
+
+        return digitsOnly.substring(0, 3)
+                + "-"
+                + digitsOnly.substring(3, 7)
+                + "-"
+                + digitsOnly.substring(7);
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #52

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- 마이페이지 프로필 및 계정 관리에 필요한 조회/수정 API를 구현
- 탈퇴 계정 재가입 복구와 탈퇴 계정 로그인 제한 로직을 추가

## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->
- MyProfileController, MyProfileService와 관련 request/response DTO를 추가해 프로필 조회, 이메일/휴대폰 번호/비밀번호 변경, 회원탈퇴 API를 구현
- User, UserRepository에 프로필 변경 및 중복 확인에 필요한 최소 메서드를 추가
- PortOneIdentityVerificationService, VerifiedIdentityDetails를 통해 휴대폰 번호 변경 시 본인인증 결과를 재사용하도록 구성
- AuthService, IdentityVerificationResponse를 수정해 탈퇴 계정 재가입 시 기존 계정을 복구하고, 탈퇴 계정은 로그인 및 토큰 재발급이 불가능하도록 처리

## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [x] 로컬에서 정상 동작 확인
- [x] API 테스트 완료 (해당되면)
- [x] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
