### PR TITLE
마이페이지 활동현황 조회 API 추가

### DIFF
--- a/src/main/java/com/shinhan/esg_be/domain/activitystatus/controller/MyActivityStatusController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/activitystatus/controller/MyActivityStatusController.java
@@ -1,0 +1,44 @@
+package com.shinhan.esg_be.domain.activitystatus.controller;
+
+import com.shinhan.esg_be.domain.activitystatus.dto.response.ActivityStatusLogResponse;
+import com.shinhan.esg_be.domain.activitystatus.dto.response.ActivityStatusOverviewResponse;
+import com.shinhan.esg_be.domain.activitystatus.service.MyActivityStatusService;
+import com.shinhan.esg_be.global.security.AuthContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/my/activity-status")
+public class MyActivityStatusController {
+
+    private final MyActivityStatusService myActivityStatusService;
+    private final AuthContext authContext;
+
+    @GetMapping("/overview")
+    public ResponseEntity<ActivityStatusOverviewResponse> getOverview() {
+        return ResponseEntity.ok(
+                myActivityStatusService.getOverview(authContext.currentUserId())
+        );
+    }
+
+    @GetMapping("/logs")
+    public ResponseEntity<ActivityStatusLogResponse> getLogs(
+            @RequestParam(defaultValue = "ALL") String category,
+            @RequestParam(defaultValue = "10") Integer size,
+            @RequestParam(required = false) String cursor
+    ) {
+        return ResponseEntity.ok(
+                myActivityStatusService.getLogs(
+                        authContext.currentUserId(),
+                        category,
+                        size,
+                        cursor
+                )
+        );
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/activitystatus/dto/response/ActivityStatusGradeHistoryItemResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/activitystatus/dto/response/ActivityStatusGradeHistoryItemResponse.java
@@ -1,0 +1,12 @@
+package com.shinhan.esg_be.domain.activitystatus.dto.response;
+
+import com.shinhan.esg_be.domain.user.entity.enums.Grade;
+
+public record ActivityStatusGradeHistoryItemResponse(
+        Integer year,
+        Integer month,
+        Grade grade,
+        Integer totalScore,
+        Boolean currentMonth
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/activitystatus/dto/response/ActivityStatusLogItemResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/activitystatus/dto/response/ActivityStatusLogItemResponse.java
@@ -1,0 +1,16 @@
+package com.shinhan.esg_be.domain.activitystatus.dto.response;
+
+import com.shinhan.esg_be.global.common.enums.ScoreReason;
+
+import java.time.LocalDateTime;
+
+public record ActivityStatusLogItemResponse(
+        Long scoreHistoryId,
+        String title,
+        String category,
+        ScoreReason reason,
+        Integer changeAmount,
+        Integer scoreAfter,
+        LocalDateTime occurredAt
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/activitystatus/dto/response/ActivityStatusLogResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/activitystatus/dto/response/ActivityStatusLogResponse.java
@@ -1,0 +1,11 @@
+package com.shinhan.esg_be.domain.activitystatus.dto.response;
+
+import java.util.List;
+
+public record ActivityStatusLogResponse(
+        Integer totalCount,
+        Boolean hasNext,
+        String nextCursor,
+        List<ActivityStatusLogItemResponse> items
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/activitystatus/dto/response/ActivityStatusMonthlyScorePointResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/activitystatus/dto/response/ActivityStatusMonthlyScorePointResponse.java
@@ -1,0 +1,9 @@
+package com.shinhan.esg_be.domain.activitystatus.dto.response;
+
+public record ActivityStatusMonthlyScorePointResponse(
+        Integer year,
+        Integer month,
+        Integer score,
+        Boolean currentMonth
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/activitystatus/dto/response/ActivityStatusOverviewResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/activitystatus/dto/response/ActivityStatusOverviewResponse.java
@@ -1,0 +1,10 @@
+package com.shinhan.esg_be.domain.activitystatus.dto.response;
+
+import java.util.List;
+
+public record ActivityStatusOverviewResponse(
+        ActivityStatusSummaryResponse summary,
+        List<ActivityStatusGradeHistoryItemResponse> gradeHistories,
+        List<ActivityStatusMonthlyScorePointResponse> monthlyScoreGraph
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/activitystatus/dto/response/ActivityStatusSummaryResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/activitystatus/dto/response/ActivityStatusSummaryResponse.java
@@ -1,0 +1,18 @@
+package com.shinhan.esg_be.domain.activitystatus.dto.response;
+
+import com.shinhan.esg_be.domain.user.entity.enums.Grade;
+
+import java.time.LocalDate;
+
+public record ActivityStatusSummaryResponse(
+        Grade currentGrade,
+        Integer totalScore,
+        Integer progressCurrent,
+        Integer progressTarget,
+        Integer progressPercent,
+        Integer currentMonthActivityCount,
+        Integer consecutiveMaxAchievementMonths,
+        Boolean showConsecutiveAchievementBadge,
+        LocalDate referenceDate
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/activitystatus/repository/ActivityStatusQueryRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/activitystatus/repository/ActivityStatusQueryRepository.java
@@ -1,0 +1,165 @@
+package com.shinhan.esg_be.domain.activitystatus.repository;
+
+import com.shinhan.esg_be.domain.score.entity.ExpiredScoreHistory;
+import com.shinhan.esg_be.domain.score.entity.ValidScoreHistory;
+import com.shinhan.esg_be.global.common.enums.ScoreCategory;
+import com.shinhan.esg_be.global.common.enums.ScoreReason;
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.TypedQuery;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.Collection;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ActivityStatusQueryRepository {
+
+    private final EntityManager entityManager;
+
+    public List<ValidScoreHistory> findHistoriesInPeriod(
+            Long userId,
+            LocalDateTime from,
+            LocalDateTime to
+    ) {
+        return entityManager.createQuery("""
+                        select v
+                        from ValidScoreHistory v
+                        where v.user.userId = :userId
+                          and v.createdAt >= :from
+                          and v.createdAt < :to
+                        order by v.createdAt desc, v.scoreId desc
+                        """, ValidScoreHistory.class)
+                .setParameter("userId", userId)
+                .setParameter("from", from)
+                .setParameter("to", to)
+                .getResultList();
+    }
+
+    public List<ValidScoreHistory> findHistoriesByReasonsInPeriod(
+            Long userId,
+            LocalDateTime from,
+            LocalDateTime to,
+            Collection<ScoreReason> reasons
+    ) {
+        return entityManager.createQuery("""
+                        select v
+                        from ValidScoreHistory v
+                        where v.user.userId = :userId
+                          and v.createdAt >= :from
+                          and v.createdAt < :to
+                          and v.reason in :reasons
+                        order by v.createdAt desc, v.scoreId desc
+                        """, ValidScoreHistory.class)
+                .setParameter("userId", userId)
+                .setParameter("from", from)
+                .setParameter("to", to)
+                .setParameter("reasons", reasons)
+                .getResultList();
+    }
+
+    public List<ExpiredScoreHistory> findExpiredHistoriesByValidUntilPeriod(
+            Long userId,
+            LocalDateTime from,
+            LocalDateTime to
+    ) {
+        return entityManager.createQuery("""
+                        select e
+                        from ExpiredScoreHistory e
+                        where e.user.userId = :userId
+                          and e.validUntil >= :from
+                          and e.validUntil < :to
+                        order by e.validUntil desc, e.scoreId desc
+                        """, ExpiredScoreHistory.class)
+                .setParameter("userId", userId)
+                .setParameter("from", from)
+                .setParameter("to", to)
+                .getResultList();
+    }
+
+    public List<ValidScoreHistory> findLogHistories(
+            Long userId,
+            LocalDateTime from,
+            Collection<ScoreReason> reasons,
+            Collection<ScoreCategory> categories,
+            LocalDateTime cursorOccurredAt,
+            Long cursorScoreId,
+            int limit
+    ) {
+        StringBuilder jpql = new StringBuilder("""
+                select v
+                from ValidScoreHistory v
+                where v.user.userId = :userId
+                  and v.createdAt >= :from
+                  and v.reason in :reasons
+                """);
+
+        if (categories != null && !categories.isEmpty()) {
+            jpql.append("""
+                      and v.category in :categories
+                    """);
+        }
+
+        if (cursorOccurredAt != null && cursorScoreId != null) {
+            jpql.append("""
+                      and (v.createdAt < :cursorOccurredAt
+                           or (v.createdAt = :cursorOccurredAt and v.scoreId < :cursorScoreId))
+                    """);
+        }
+
+        jpql.append("""
+                  order by v.createdAt desc, v.scoreId desc
+                """);
+
+        TypedQuery<ValidScoreHistory> query = entityManager.createQuery(jpql.toString(), ValidScoreHistory.class)
+                .setParameter("userId", userId)
+                .setParameter("from", from)
+                .setParameter("reasons", reasons)
+                .setMaxResults(limit);
+
+        if (categories != null && !categories.isEmpty()) {
+            query.setParameter("categories", categories);
+        }
+
+        if (cursorOccurredAt != null && cursorScoreId != null) {
+            query.setParameter("cursorOccurredAt", cursorOccurredAt);
+            query.setParameter("cursorScoreId", cursorScoreId);
+        }
+
+        return query.getResultList();
+    }
+
+    public long countLogHistories(
+            Long userId,
+            LocalDateTime from,
+            Collection<ScoreReason> reasons,
+            Collection<ScoreCategory> categories
+    ) {
+        StringBuilder jpql = new StringBuilder("""
+                select count(v)
+                from ValidScoreHistory v
+                where v.user.userId = :userId
+                  and v.createdAt >= :from
+                  and v.reason in :reasons
+                """);
+
+        if (categories != null && !categories.isEmpty()) {
+            jpql.append("""
+                      and v.category in :categories
+                    """);
+        }
+
+        TypedQuery<Long> query = entityManager.createQuery(jpql.toString(), Long.class)
+                .setParameter("userId", userId)
+                .setParameter("from", from)
+                .setParameter("reasons", reasons);
+
+        if (categories != null && !categories.isEmpty()) {
+            query.setParameter("categories", categories);
+        }
+
+        return query.getSingleResult();
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/activitystatus/service/MyActivityStatusService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/activitystatus/service/MyActivityStatusService.java
@@ -1,0 +1,439 @@
+package com.shinhan.esg_be.domain.activitystatus.service;
+
+import com.shinhan.esg_be.domain.activitystatus.dto.response.ActivityStatusGradeHistoryItemResponse;
+import com.shinhan.esg_be.domain.activitystatus.dto.response.ActivityStatusLogItemResponse;
+import com.shinhan.esg_be.domain.activitystatus.dto.response.ActivityStatusLogResponse;
+import com.shinhan.esg_be.domain.activitystatus.dto.response.ActivityStatusMonthlyScorePointResponse;
+import com.shinhan.esg_be.domain.activitystatus.dto.response.ActivityStatusOverviewResponse;
+import com.shinhan.esg_be.domain.activitystatus.dto.response.ActivityStatusSummaryResponse;
+import com.shinhan.esg_be.domain.policy.entity.EsgScorePolicy;
+import com.shinhan.esg_be.domain.policy.repository.EsgScorePolicyRepository;
+import com.shinhan.esg_be.domain.activitystatus.repository.ActivityStatusQueryRepository;
+import com.shinhan.esg_be.domain.score.entity.ExpiredScoreHistory;
+import com.shinhan.esg_be.domain.score.entity.ValidScoreHistory;
+import com.shinhan.esg_be.domain.stat.entity.UserMonthlyStat;
+import com.shinhan.esg_be.domain.stat.repository.UserMonthlyStatRepository;
+import com.shinhan.esg_be.domain.user.entity.User;
+import com.shinhan.esg_be.domain.user.entity.enums.Grade;
+import com.shinhan.esg_be.domain.user.repository.UserRepository;
+import com.shinhan.esg_be.global.common.enums.ScoreCategory;
+import com.shinhan.esg_be.global.common.enums.ScoreReason;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.YearMonth;
+import java.time.format.DateTimeParseException;
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyActivityStatusService {
+
+    private static final int MAX_SCORE = 1000;
+    private static final int OVERVIEW_MONTH_COUNT = 4;
+    private static final int RECENT_MONTH_LOOKBACK_COUNT = 12;
+    private static final int DEFAULT_LOG_SIZE = 10;
+    private static final int MAX_LOG_SIZE = 50;
+    private static final List<ScoreCategory> MONTHLY_TARGET_CATEGORIES = List.of(
+            ScoreCategory.E,
+            ScoreCategory.S,
+            ScoreCategory.G_ACTIVITY
+    );
+
+    private static final Set<ScoreReason> ACTIVITY_REASONS = EnumSet.of(
+            ScoreReason.DONATION,
+            ScoreReason.VOLUNTEER,
+            ScoreReason.PURCHASE,
+            ScoreReason.QUIZ,
+            ScoreReason.PHOTO,
+            ScoreReason.LOAN_REPAY
+    );
+
+    private static final Set<ScoreReason> LOG_VISIBLE_REASONS = EnumSet.of(
+            ScoreReason.DONATION,
+            ScoreReason.VOLUNTEER,
+            ScoreReason.PURCHASE,
+            ScoreReason.QUIZ,
+            ScoreReason.PHOTO,
+            ScoreReason.LOAN_REPAY,
+            ScoreReason.CONSECUTIVE_BONUS
+    );
+
+    private final UserRepository userRepository;
+    private final ActivityStatusQueryRepository activityStatusQueryRepository;
+    private final UserMonthlyStatRepository userMonthlyStatRepository;
+    private final EsgScorePolicyRepository esgScorePolicyRepository;
+    private final Clock clock;
+
+    public ActivityStatusOverviewResponse getOverview(Long userId) {
+        User user = getUser(userId);
+        LocalDate today = LocalDate.now(clock);
+        List<MonthScoreSnapshot> monthSnapshots = buildMonthSnapshots(user, today);
+
+        return new ActivityStatusOverviewResponse(
+                buildSummary(user, today),
+                monthSnapshots.stream()
+                        .map(this::toGradeHistoryItemResponse)
+                        .toList(),
+                monthSnapshots.stream()
+                        .map(this::toMonthlyScorePointResponse)
+                        .toList()
+        );
+    }
+
+    public ActivityStatusLogResponse getLogs(
+            Long userId,
+            String category,
+            Integer size,
+            String cursor
+    ) {
+        getUser(userId);
+
+        ActivityStatusFilter filter = ActivityStatusFilter.from(category);
+        CursorPageRequest pageRequest = buildPageRequest(size, cursor);
+        LocalDateTime from = LocalDate.now(clock).minusYears(1).atStartOfDay();
+
+        List<ScoreCategory> categories = filter.toCategories();
+        List<ValidScoreHistory> histories = activityStatusQueryRepository.findLogHistories(
+                userId,
+                from,
+                LOG_VISIBLE_REASONS,
+                categories,
+                pageRequest.cursorOccurredAt(),
+                pageRequest.cursorScoreId(),
+                pageRequest.limit() + 1
+        );
+
+        boolean hasNext = histories.size() > pageRequest.limit();
+        List<ValidScoreHistory> pageItems = hasNext
+                ? histories.subList(0, pageRequest.limit())
+                : histories;
+
+        String nextCursor = hasNext && !pageItems.isEmpty()
+                ? buildCursor(pageItems.get(pageItems.size() - 1))
+                : null;
+
+        long totalCount = activityStatusQueryRepository.countLogHistories(
+                userId,
+                from,
+                LOG_VISIBLE_REASONS,
+                categories
+        );
+
+        return new ActivityStatusLogResponse(
+                Math.toIntExact(totalCount),
+                hasNext,
+                nextCursor,
+                pageItems.stream()
+                        .map(this::toLogItemResponse)
+                        .toList()
+        );
+    }
+
+    private User getUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "User not found."));
+    }
+
+    private ActivityStatusSummaryResponse buildSummary(User user, LocalDate today) {
+        ProgressSummary progressSummary = buildProgressSummary(user.getTotalScore());
+        LocalDateTime currentMonthStart = today.withDayOfMonth(1).atStartOfDay();
+        LocalDateTime nextMonthStart = currentMonthStart.plusMonths(1);
+
+        int currentMonthActivityCount = activityStatusQueryRepository.findHistoriesByReasonsInPeriod(
+                user.getUserId(),
+                currentMonthStart,
+                nextMonthStart,
+                ACTIVITY_REASONS
+        ).size();
+        ConsecutiveAchievementBadgeSummary badgeSummary = buildConsecutiveAchievementBadgeSummary(user);
+
+        return new ActivityStatusSummaryResponse(
+                user.getCurrentGrade(),
+                user.getTotalScore(),
+                progressSummary.current(),
+                progressSummary.target(),
+                progressSummary.percent(),
+                currentMonthActivityCount,
+                badgeSummary.consecutiveMonths(),
+                badgeSummary.visible(),
+                today
+        );
+    }
+
+    private List<MonthScoreSnapshot> buildMonthSnapshots(User user, LocalDate today) {
+        YearMonth currentMonth = YearMonth.from(today);
+        List<YearMonth> months = new ArrayList<>();
+        for (int index = OVERVIEW_MONTH_COUNT - 1; index >= 0; index--) {
+            months.add(currentMonth.minusMonths(index));
+        }
+
+        LocalDateTime from = months.get(0).atDay(1).atStartOfDay();
+        LocalDateTime to = currentMonth.plusMonths(1).atDay(1).atStartOfDay();
+
+        List<ValidScoreHistory> histories = activityStatusQueryRepository.findHistoriesInPeriod(
+                user.getUserId(),
+                from,
+                to
+        );
+        List<ExpiredScoreHistory> expiredHistories = activityStatusQueryRepository.findExpiredHistoriesByValidUntilPeriod(
+                user.getUserId(),
+                from,
+                to
+        );
+
+        Map<YearMonth, Integer> monthlyNetDeltaByMonth = new HashMap<>();
+        for (ValidScoreHistory history : histories) {
+            YearMonth yearMonth = YearMonth.from(history.getCreatedAt());
+            monthlyNetDeltaByMonth.merge(yearMonth, history.getChangeAmount(), Integer::sum);
+        }
+        for (ExpiredScoreHistory history : expiredHistories) {
+            YearMonth yearMonth = YearMonth.from(history.getValidUntil());
+            monthlyNetDeltaByMonth.merge(yearMonth, -history.getChangeAmount(), Integer::sum);
+        }
+
+        Map<YearMonth, Integer> monthEndScoreByMonth = new HashMap<>();
+        int rollingScore = user.getTotalScore();
+        for (int index = months.size() - 1; index >= 0; index--) {
+            YearMonth yearMonth = months.get(index);
+            monthEndScoreByMonth.put(yearMonth, rollingScore);
+            rollingScore -= monthlyNetDeltaByMonth.getOrDefault(yearMonth, 0);
+        }
+
+        return months.stream()
+                .map(yearMonth -> new MonthScoreSnapshot(
+                        yearMonth.getYear(),
+                        yearMonth.getMonthValue(),
+                        monthEndScoreByMonth.getOrDefault(yearMonth, user.getTotalScore()),
+                        yearMonth.equals(currentMonth)
+                ))
+                .toList();
+    }
+
+    private ConsecutiveAchievementBadgeSummary buildConsecutiveAchievementBadgeSummary(User user) {
+        UserMonthlyStat userMonthlyStat = userMonthlyStatRepository.findByUser(user)
+                .orElse(null);
+        if (userMonthlyStat == null) {
+            return new ConsecutiveAchievementBadgeSummary(0, false);
+        }
+
+        Map<ScoreCategory, Integer> monthlyMaxScoreByCategory = loadMonthlyMaxScoreByCategory();
+        boolean achievedAllMonthlyTargets = MONTHLY_TARGET_CATEGORIES.stream()
+                .allMatch(category -> userMonthlyStat.getMonthlyScore(category) >= monthlyMaxScoreByCategory.get(category));
+
+        if (!achievedAllMonthlyTargets) {
+            return new ConsecutiveAchievementBadgeSummary(0, false);
+        }
+
+        int consecutiveMonths = Math.min(
+                userMonthlyStat.getConsecutiveEMaxScore(),
+                Math.min(
+                        userMonthlyStat.getConsecutiveSMaxScore(),
+                        userMonthlyStat.getConsecutiveGMaxScore()
+                )
+        ) + 1;
+
+        return new ConsecutiveAchievementBadgeSummary(consecutiveMonths, consecutiveMonths > 0);
+    }
+
+    private Map<ScoreCategory, Integer> loadMonthlyMaxScoreByCategory() {
+        Map<ScoreCategory, Integer> monthlyMaxScoreByCategory = new HashMap<>();
+        for (ScoreCategory category : MONTHLY_TARGET_CATEGORIES) {
+            EsgScorePolicy policy = esgScorePolicyRepository.findByCategoryAndIsActiveTrue(category)
+                    .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "ESG score policy not found."));
+            monthlyMaxScoreByCategory.put(category, defaultIfNull(policy.getMonthlyMaxScore()));
+        }
+        return monthlyMaxScoreByCategory;
+    }
+
+    private ProgressSummary buildProgressSummary(int totalScore) {
+        int displayScore = Math.max(0, Math.min(totalScore, MAX_SCORE));
+        int target = MAX_SCORE;
+        int current = displayScore;
+        int percent = (int) Math.round((current * 100.0) / target);
+
+        return new ProgressSummary(current, target, Math.max(0, Math.min(percent, 100)));
+    }
+
+    private Grade resolveGrade(int totalScore) {
+        if (totalScore >= 900) {
+            return Grade.EARTH;
+        }
+        if (totalScore >= 800) {
+            return Grade.FOREST;
+        }
+        if (totalScore >= 700) {
+            return Grade.TREE;
+        }
+        if (totalScore >= 600) {
+            return Grade.SPROUT;
+        }
+        return Grade.SEED;
+    }
+
+    private ActivityStatusGradeHistoryItemResponse toGradeHistoryItemResponse(MonthScoreSnapshot snapshot) {
+        return new ActivityStatusGradeHistoryItemResponse(
+                snapshot.year(),
+                snapshot.month(),
+                resolveGrade(snapshot.totalScore()),
+                snapshot.totalScore(),
+                snapshot.currentMonth()
+        );
+    }
+
+    private ActivityStatusMonthlyScorePointResponse toMonthlyScorePointResponse(MonthScoreSnapshot snapshot) {
+        return new ActivityStatusMonthlyScorePointResponse(
+                snapshot.year(),
+                snapshot.month(),
+                snapshot.totalScore(),
+                snapshot.currentMonth()
+        );
+    }
+
+    private ActivityStatusLogItemResponse toLogItemResponse(ValidScoreHistory history) {
+        return new ActivityStatusLogItemResponse(
+                history.getScoreId(),
+                resolveLogTitle(history.getReason()),
+                toResponseCategory(history.getCategory()),
+                history.getReason(),
+                history.getChangeAmount(),
+                history.getScoreAfter(),
+                history.getCreatedAt()
+        );
+    }
+
+    private String resolveLogTitle(ScoreReason scoreReason) {
+        return switch (scoreReason) {
+            case DONATION -> "기부 참여";
+            case VOLUNTEER -> "봉사 활동 참여";
+            case PURCHASE -> "친환경 제품 구매";
+            case QUIZ -> "ESG 퀴즈 참여";
+            case PHOTO -> "친환경 인증";
+            case LOAN_REPAY -> "대출 상환";
+            case CONSECUTIVE_BONUS -> "연속 활동 보너스";
+            case ABUSE -> "부정 이용 패널티";
+            case NO_ACTIVITY -> "미활동 패널티";
+            case INITIAL_SCORE -> "초기 점수";
+        };
+    }
+
+    private String toResponseCategory(ScoreCategory scoreCategory) {
+        return switch (scoreCategory) {
+            case E -> "E";
+            case S -> "S";
+            case G_ACTIVITY, G_REPAYMENT -> "G";
+        };
+    }
+
+    private CursorPageRequest buildPageRequest(Integer size, String cursor) {
+        int resolvedSize = size == null ? DEFAULT_LOG_SIZE : size;
+        if (resolvedSize <= 0) {
+            throw new ResponseStatusException(BAD_REQUEST, "size must be greater than 0.");
+        }
+
+        int limit = Math.min(resolvedSize, MAX_LOG_SIZE);
+        LogCursor parsedCursor = parseCursor(cursor);
+        return new CursorPageRequest(limit, parsedCursor.occurredAt(), parsedCursor.scoreId());
+    }
+
+    private LogCursor parseCursor(String cursor) {
+        if (cursor == null || cursor.isBlank()) {
+            return new LogCursor(null, null);
+        }
+
+        String[] tokens = cursor.split("\\|");
+        if (tokens.length != 2) {
+            throw new ResponseStatusException(BAD_REQUEST, "Invalid cursor format.");
+        }
+
+        try {
+            return new LogCursor(LocalDateTime.parse(tokens[0]), Long.parseLong(tokens[1]));
+        } catch (DateTimeParseException | NumberFormatException exception) {
+            throw new ResponseStatusException(BAD_REQUEST, "Invalid cursor format.");
+        }
+    }
+
+    private String buildCursor(ValidScoreHistory history) {
+        return history.getCreatedAt() + "|" + history.getScoreId();
+    }
+
+    private int defaultIfNull(Integer value) {
+        return value == null ? 0 : value;
+    }
+
+    private record MonthScoreSnapshot(
+            Integer year,
+            Integer month,
+            Integer totalScore,
+            Boolean currentMonth
+    ) {
+    }
+
+    private record ProgressSummary(
+            Integer current,
+            Integer target,
+            Integer percent
+    ) {
+    }
+
+    private record ConsecutiveAchievementBadgeSummary(
+            Integer consecutiveMonths,
+            Boolean visible
+    ) {
+    }
+
+    private record CursorPageRequest(
+            int limit,
+            LocalDateTime cursorOccurredAt,
+            Long cursorScoreId
+    ) {
+    }
+
+    private record LogCursor(
+            LocalDateTime occurredAt,
+            Long scoreId
+    ) {
+    }
+
+    private enum ActivityStatusFilter {
+        ALL,
+        E,
+        S,
+        G;
+
+        static ActivityStatusFilter from(String value) {
+            if (value == null || value.isBlank()) {
+                return ALL;
+            }
+
+            try {
+                return ActivityStatusFilter.valueOf(value.toUpperCase());
+            } catch (IllegalArgumentException exception) {
+                throw new ResponseStatusException(BAD_REQUEST, "Invalid category value.");
+            }
+        }
+
+        List<ScoreCategory> toCategories() {
+            return switch (this) {
+                case ALL -> List.of();
+                case E -> List.of(ScoreCategory.E);
+                case S -> List.of(ScoreCategory.S);
+                case G -> List.of(ScoreCategory.G_ACTIVITY, ScoreCategory.G_REPAYMENT);
+            };
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #58

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- 마이페이지 ESG 활동 현황 조회 API 구현
- 활동현황 요약 정보, 월별 점수 변화, 점수 획득 내역 조회 로직 구현

## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->
- activitystatus 도메인 추가
- GET /api/my/activity-status/overview API 구현
    - 현재 등급/총점
    - 0~1000 기준 프로그래스 정보
    - 이번 달 활동 수
    - 연속 활동 뱃지 노출 여부 및 연속 개월 수
    - 최근 4개월 등급 변화 이력
    - 최근 4개월 월별 점수 변화 그래프 데이터 조회
- GET /api/my/activity-status/logs API 구현
    - 최근 1년 점수 획득 내역 조회
    - 전체 / E / S / G 카테고리 필터링 지원
    - 커서 기반 더보기 조회 지원
- 연속 활동 뱃지 로직 구현
    - 현재 월 E / S / G가 모두 월 최대 점수 상한선에 도달한 경우에만 노출
- 월별 점수 변화 그래프 정확도 보정
    - valid_score_history.createdAt 기준 획득 점수 반영
    - expired_score_history.validUntil 기준 만료 점수 반영
- 활동현황 응답 전용 DTO 추가 및 프론트 연동 가능한 응답 구조 정리

## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [x] 로컬에서 정상 동작 확인
- [x] API 테스트 완료 (해당되면)
- [x] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
