### PR TITLE
67 feat esg 활동 보고서 기능 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,11 @@ dependencies {
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+
+	implementation 'com.openhtmltopdf:openhtmltopdf-pdfbox:1.0.10'
+	implementation 'com.google.zxing:core:3.5.3'
+	implementation 'com.google.zxing:javase:3.5.3'
+	implementation 'com.twelvemonkeys.imageio:imageio-webp:3.11.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/shinhan/esg_be/domain/report/controller/MyReportController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/controller/MyReportController.java
@@ -1,0 +1,63 @@
+package com.shinhan.esg_be.domain.report.controller;
+
+import com.shinhan.esg_be.domain.report.dto.response.ReportPreviewResponse;
+import com.shinhan.esg_be.domain.report.dto.response.ReportPdfFile;
+import com.shinhan.esg_be.domain.report.dto.request.ReportIssueRequest;
+import com.shinhan.esg_be.domain.report.dto.response.ReportIssueResponse;
+import com.shinhan.esg_be.domain.report.service.ReportIssueService;
+import com.shinhan.esg_be.domain.report.service.MyReportService;
+import com.shinhan.esg_be.domain.report.service.ReportPdfService;
+import com.shinhan.esg_be.global.security.AuthContext;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/my/reports")
+public class MyReportController {
+
+    private final MyReportService myReportService;
+    private final ReportIssueService reportIssueService;
+    private final ReportPdfService reportPdfService;
+    private final AuthContext authContext;
+
+    @GetMapping("/preview")
+    public ResponseEntity<ReportPreviewResponse> getPreview(
+            @RequestParam(defaultValue = "3M") String periodType
+    ) {
+        return ResponseEntity.ok(
+                myReportService.getPreview(authContext.currentUserId(), periodType)
+        );
+    }
+
+    @PostMapping("/issues")
+    public ResponseEntity<ReportIssueResponse> issue(
+            @Valid @RequestBody ReportIssueRequest request
+    ) {
+        return ResponseEntity.ok(
+                reportIssueService.issue(authContext.currentUserId(), request)
+        );
+    }
+
+    @GetMapping("/issues/{issueId}/pdf")
+    public ResponseEntity<byte[]> downloadPdf(
+            @PathVariable Long issueId
+    ) {
+        ReportPdfFile pdfFile = reportPdfService.download(authContext.currentUserId(), issueId);
+
+        return ResponseEntity.ok()
+                .contentType(MediaType.APPLICATION_PDF)
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=\"" + pdfFile.fileName() + "\"")
+                .body(pdfFile.content());
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/controller/ReportVerificationController.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/controller/ReportVerificationController.java
@@ -1,0 +1,25 @@
+package com.shinhan.esg_be.domain.report.controller;
+
+import com.shinhan.esg_be.domain.report.dto.response.ReportVerificationResponse;
+import com.shinhan.esg_be.domain.report.service.ReportVerificationService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/reports")
+public class ReportVerificationController {
+
+    private final ReportVerificationService reportVerificationService;
+
+    @GetMapping("/verify/{token}")
+    public ResponseEntity<ReportVerificationResponse> verify(
+            @PathVariable String token
+    ) {
+        return ResponseEntity.ok(reportVerificationService.verify(token));
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/dto/request/ReportIssueRequest.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/dto/request/ReportIssueRequest.java
@@ -1,0 +1,11 @@
+package com.shinhan.esg_be.domain.report.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ReportIssueRequest(
+        @NotBlank
+        @Pattern(regexp = "^(3M|6M|1Y)$", message = "periodType must be one of 3M, 6M, 1Y.")
+        String periodType
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/dto/request/ReportPreviewRequest.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/dto/request/ReportPreviewRequest.java
@@ -1,0 +1,11 @@
+package com.shinhan.esg_be.domain.report.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+public record ReportPreviewRequest(
+        @NotBlank
+        @Pattern(regexp = "^(3M|6M|1Y)$", message = "periodType must be one of 3M, 6M, 1Y.")
+        String periodType
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/dto/response/ReportCategorySummaryResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/dto/response/ReportCategorySummaryResponse.java
@@ -1,0 +1,9 @@
+package com.shinhan.esg_be.domain.report.dto.response;
+
+public record ReportCategorySummaryResponse(
+        String categoryKey,
+        String label,
+        Integer value,
+        String unit
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/dto/response/ReportCertificateMetaResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/dto/response/ReportCertificateMetaResponse.java
@@ -1,0 +1,12 @@
+package com.shinhan.esg_be.domain.report.dto.response;
+
+import java.time.LocalDateTime;
+
+public record ReportCertificateMetaResponse(
+        Long issueId,
+        String certificateNumber,
+        String verificationCode,
+        String verificationUrl,
+        LocalDateTime issuedAt
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/dto/response/ReportCertificateSnapshotResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/dto/response/ReportCertificateSnapshotResponse.java
@@ -1,0 +1,22 @@
+package com.shinhan.esg_be.domain.report.dto.response;
+
+import com.shinhan.esg_be.domain.user.entity.enums.Grade;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record ReportCertificateSnapshotResponse(
+        String recipientName,
+        String periodType,
+        String periodLabel,
+        LocalDate referenceDate,
+        LocalDate targetStartDate,
+        LocalDate targetEndDate,
+        Grade currentGrade,
+        Integer totalScore,
+        Integer verifiedActivityCount,
+        Integer consecutiveMaxAchievementMonths,
+        Boolean showConsecutiveAchievementBadge,
+        List<ReportCategorySummaryResponse> categories
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/dto/response/ReportIssueResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/dto/response/ReportIssueResponse.java
@@ -1,0 +1,7 @@
+package com.shinhan.esg_be.domain.report.dto.response;
+
+public record ReportIssueResponse(
+        ReportCertificateMetaResponse certificate,
+        ReportCertificateSnapshotResponse snapshot
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/dto/response/ReportPdfFile.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/dto/response/ReportPdfFile.java
@@ -1,0 +1,7 @@
+package com.shinhan.esg_be.domain.report.dto.response;
+
+public record ReportPdfFile(
+        String fileName,
+        byte[] content
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/dto/response/ReportPreviewResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/dto/response/ReportPreviewResponse.java
@@ -1,0 +1,6 @@
+package com.shinhan.esg_be.domain.report.dto.response;
+
+public record ReportPreviewResponse(
+        ReportCertificateSnapshotResponse snapshot
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/dto/response/ReportVerificationResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/dto/response/ReportVerificationResponse.java
@@ -1,0 +1,9 @@
+package com.shinhan.esg_be.domain.report.dto.response;
+
+public record ReportVerificationResponse(
+        Boolean valid,
+        String verificationStatus,
+        ReportCertificateMetaResponse certificate,
+        ReportCertificateSnapshotResponse snapshot
+) {
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/entity/ReportIssue.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/entity/ReportIssue.java
@@ -1,0 +1,152 @@
+package com.shinhan.esg_be.domain.report.entity;
+
+import com.shinhan.esg_be.domain.user.entity.User;
+import com.shinhan.esg_be.global.common.BaseTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "report_issue")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ReportIssue extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "report_issue_id")
+    private Long reportIssueId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "period_type", nullable = false, length = 2)
+    private String periodType;
+
+    @Column(name = "certificate_number", nullable = false, unique = true, length = 50)
+    private String certificateNumber;
+
+    @Column(name = "verification_code", nullable = false, unique = true, length = 50)
+    private String verificationCode;
+
+    @Column(name = "verification_token", nullable = false, unique = true, length = 128)
+    private String verificationToken;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private ReportIssueStatus status = ReportIssueStatus.ACTIVE;
+
+    @Column(name = "issued_at", nullable = false)
+    private LocalDateTime issuedAt;
+
+    @Column(name = "target_start_date", nullable = false)
+    private LocalDate targetStartDate;
+
+    @Column(name = "target_end_date", nullable = false)
+    private LocalDate targetEndDate;
+
+    @Column(name = "recipient_name", nullable = false, length = 100)
+    private String recipientName;
+
+    @Column(name = "grade", nullable = false, length = 20)
+    private String grade;
+
+    @Column(name = "total_score", nullable = false)
+    private Integer totalScore;
+
+    @Column(name = "verified_activity_count", nullable = false)
+    private Integer verifiedActivityCount;
+
+    @Column(name = "consecutive_max_achievement_months", nullable = false)
+    private Integer consecutiveMaxAchievementMonths = 0;
+
+    @Column(name = "show_consecutive_achievement_badge", nullable = false)
+    private Boolean showConsecutiveAchievementBadge = false;
+
+    @Column(name = "environment_activity_count", nullable = false)
+    private Integer environmentActivityCount = 0;
+
+    @Column(name = "volunteer_hours", nullable = false)
+    private Integer volunteerHours = 0;
+
+    @Column(name = "social_contribution_count", nullable = false)
+    private Integer socialContributionCount = 0;
+
+    @Column(name = "trust_activity_count", nullable = false)
+    private Integer trustActivityCount = 0;
+
+    public static ReportIssue create(
+            User user,
+            String periodType,
+            String certificateNumber,
+            String verificationCode,
+            String verificationToken,
+            LocalDateTime issuedAt,
+            LocalDate targetStartDate,
+            LocalDate targetEndDate,
+            String recipientName,
+            String grade,
+            Integer totalScore,
+            Integer verifiedActivityCount,
+            Integer consecutiveMaxAchievementMonths,
+            Boolean showConsecutiveAchievementBadge,
+            Integer environmentActivityCount,
+            Integer volunteerHours,
+            Integer socialContributionCount,
+            Integer trustActivityCount
+    ) {
+        ReportIssue reportIssue = new ReportIssue();
+        reportIssue.user = user;
+        reportIssue.periodType = periodType;
+        reportIssue.certificateNumber = certificateNumber;
+        reportIssue.verificationCode = verificationCode;
+        reportIssue.verificationToken = verificationToken;
+        reportIssue.status = ReportIssueStatus.ACTIVE;
+        reportIssue.issuedAt = issuedAt;
+        reportIssue.targetStartDate = targetStartDate;
+        reportIssue.targetEndDate = targetEndDate;
+        reportIssue.recipientName = recipientName;
+        reportIssue.grade = grade;
+        reportIssue.totalScore = totalScore;
+        reportIssue.verifiedActivityCount = verifiedActivityCount;
+        reportIssue.consecutiveMaxAchievementMonths = defaultIfNull(consecutiveMaxAchievementMonths);
+        reportIssue.showConsecutiveAchievementBadge = defaultIfNull(showConsecutiveAchievementBadge);
+        reportIssue.environmentActivityCount = defaultIfNull(environmentActivityCount);
+        reportIssue.volunteerHours = defaultIfNull(volunteerHours);
+        reportIssue.socialContributionCount = defaultIfNull(socialContributionCount);
+        reportIssue.trustActivityCount = defaultIfNull(trustActivityCount);
+        return reportIssue;
+    }
+
+    public void revoke() {
+        this.status = ReportIssueStatus.REVOKED;
+    }
+
+    private static int defaultIfNull(Integer value) {
+        return value == null ? 0 : value;
+    }
+
+    private static boolean defaultIfNull(Boolean value) {
+        return value != null && value;
+    }
+
+    public enum ReportIssueStatus {
+        ACTIVE,
+        REVOKED
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/entity/enums/ReportPeriodType.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/entity/enums/ReportPeriodType.java
@@ -1,0 +1,49 @@
+package com.shinhan.esg_be.domain.report.entity.enums;
+
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+public enum ReportPeriodType {
+    THREE_MONTHS("3M", "최근 3개월", 3),
+    SIX_MONTHS("6M", "최근 6개월", 6),
+    ONE_YEAR("1Y", "최근 1년", 12);
+
+    private final String code;
+    private final String label;
+    private final int months;
+
+    ReportPeriodType(String code, String label, int months) {
+        this.code = code;
+        this.label = label;
+        this.months = months;
+    }
+
+    public static ReportPeriodType from(String code) {
+        for (ReportPeriodType value : values()) {
+            if (value.code.equalsIgnoreCase(code)) {
+                return value;
+            }
+        }
+        throw new ResponseStatusException(BAD_REQUEST, "Invalid periodType.");
+    }
+
+    public String code() {
+        return code;
+    }
+
+    public String label() {
+        return label;
+    }
+
+    public LocalDateTime startDateTime(LocalDate referenceDate) {
+        return referenceDate.minusMonths(months).atStartOfDay();
+    }
+
+    public LocalDateTime endDateTime(LocalDate referenceDate) {
+        return referenceDate.plusDays(1).atStartOfDay();
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/repository/ReportIssueRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/repository/ReportIssueRepository.java
@@ -1,0 +1,22 @@
+package com.shinhan.esg_be.domain.report.repository;
+
+import com.shinhan.esg_be.domain.report.entity.ReportIssue;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public interface ReportIssueRepository extends JpaRepository<ReportIssue, Long> {
+
+    boolean existsByCertificateNumber(String certificateNumber);
+
+    boolean existsByVerificationCode(String verificationCode);
+
+    boolean existsByVerificationToken(String verificationToken);
+
+    Optional<ReportIssue> findByVerificationToken(String verificationToken);
+
+    Optional<ReportIssue> findByReportIssueIdAndUser_UserId(Long reportIssueId, Long userId);
+
+    long deleteByIssuedAtBefore(LocalDateTime cutoff);
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/repository/ReportQueryRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/repository/ReportQueryRepository.java
@@ -1,0 +1,167 @@
+package com.shinhan.esg_be.domain.report.repository;
+
+import com.shinhan.esg_be.domain.volunteer.entity.enums.VolunteerStatus;
+import jakarta.persistence.EntityManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Repository
+@RequiredArgsConstructor
+public class ReportQueryRepository {
+
+    private final EntityManager entityManager;
+
+    public long countApprovedEnvironmentActivities(Long userId, LocalDateTime from, LocalDateTime to) {
+        return entityManager.createQuery("""
+                        select count(ua)
+                        from UserEnvironmentActivity ua
+                        where ua.user.userId = :userId
+                          and ua.isApproved = true
+                          and ua.createdAt >= :from
+                          and ua.createdAt < :to
+                        """, Long.class)
+                .setParameter("userId", userId)
+                .setParameter("from", from)
+                .setParameter("to", to)
+                .getSingleResult();
+    }
+
+    public long countCompletedVolunteerActivities(Long userId, LocalDateTime from, LocalDateTime to) {
+        return entityManager.createQuery("""
+                        select count(uv)
+                        from UserVolunteer uv
+                        where uv.user.userId = :userId
+                          and uv.status = :completedStatus
+                          and uv.volunteer.activityDate >= :from
+                          and uv.volunteer.activityDate < :to
+                        """, Long.class)
+                .setParameter("userId", userId)
+                .setParameter("completedStatus", VolunteerStatus.COMPLETED)
+                .setParameter("from", from)
+                .setParameter("to", to)
+                .getSingleResult();
+    }
+
+    public int sumCompletedVolunteerHours(Long userId, LocalDateTime from, LocalDateTime to) {
+        Long result = entityManager.createQuery("""
+                        select coalesce(sum(uv.volunteerHour), 0L)
+                        from UserVolunteer uv
+                        where uv.user.userId = :userId
+                          and uv.status = :completedStatus
+                          and uv.volunteer.activityDate >= :from
+                          and uv.volunteer.activityDate < :to
+                        """, Long.class)
+                .setParameter("userId", userId)
+                .setParameter("completedStatus", VolunteerStatus.COMPLETED)
+                .setParameter("from", from)
+                .setParameter("to", to)
+                .getSingleResult();
+
+        return result == null ? 0 : Math.toIntExact(result);
+    }
+
+    public long countDonations(Long userId, LocalDateTime from, LocalDateTime to) {
+        return entityManager.createQuery("""
+                        select count(ud)
+                        from UserDonation ud
+                        where ud.user.userId = :userId
+                          and ud.createdAt >= :from
+                          and ud.createdAt < :to
+                        """, Long.class)
+                .setParameter("userId", userId)
+                .setParameter("from", from)
+                .setParameter("to", to)
+                .getSingleResult();
+    }
+
+    public long countEcoProductPurchases(Long userId, LocalDateTime from, LocalDateTime to) {
+        return entityManager.createQuery("""
+                        select count(uep)
+                        from UserEcoProduct uep
+                        where uep.user.userId = :userId
+                          and uep.createdAt >= :from
+                          and uep.createdAt < :to
+                        """, Long.class)
+                .setParameter("userId", userId)
+                .setParameter("from", from)
+                .setParameter("to", to)
+                .getSingleResult();
+    }
+
+    public long countQuizActivities(Long userId, LocalDateTime from, LocalDateTime to) {
+        return entityManager.createQuery("""
+                        select count(uq)
+                        from UserQuiz uq
+                        where uq.user.userId = :userId
+                          and uq.createdAt >= :from
+                          and uq.createdAt < :to
+                        """, Long.class)
+                .setParameter("userId", userId)
+                .setParameter("from", from)
+                .setParameter("to", to)
+                .getSingleResult();
+    }
+
+    public LocalDate findFirstActivityDate(Long userId) {
+        List<LocalDateTime> candidates = new ArrayList<>();
+
+        addIfNotNull(candidates, entityManager.createQuery("""
+                        select min(ua.createdAt)
+                        from UserEnvironmentActivity ua
+                        where ua.user.userId = :userId
+                          and ua.isApproved = true
+                        """, LocalDateTime.class)
+                .setParameter("userId", userId)
+                .getSingleResult());
+
+        addIfNotNull(candidates, entityManager.createQuery("""
+                        select min(uv.volunteer.activityDate)
+                        from UserVolunteer uv
+                        where uv.user.userId = :userId
+                          and uv.status = :completedStatus
+                        """, LocalDateTime.class)
+                .setParameter("userId", userId)
+                .setParameter("completedStatus", VolunteerStatus.COMPLETED)
+                .getSingleResult());
+
+        addIfNotNull(candidates, entityManager.createQuery("""
+                        select min(ud.createdAt)
+                        from UserDonation ud
+                        where ud.user.userId = :userId
+                        """, LocalDateTime.class)
+                .setParameter("userId", userId)
+                .getSingleResult());
+
+        addIfNotNull(candidates, entityManager.createQuery("""
+                        select min(uep.createdAt)
+                        from UserEcoProduct uep
+                        where uep.user.userId = :userId
+                        """, LocalDateTime.class)
+                .setParameter("userId", userId)
+                .getSingleResult());
+
+        addIfNotNull(candidates, entityManager.createQuery("""
+                        select min(uq.createdAt)
+                        from UserQuiz uq
+                        where uq.user.userId = :userId
+                        """, LocalDateTime.class)
+                .setParameter("userId", userId)
+                .getSingleResult());
+
+        return candidates.stream()
+                .min(LocalDateTime::compareTo)
+                .map(LocalDateTime::toLocalDate)
+                .orElse(null);
+    }
+
+    private void addIfNotNull(List<LocalDateTime> candidates, LocalDateTime value) {
+        if (value != null) {
+            candidates.add(value);
+        }
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/scheduler/ReportIssueCleanupScheduler.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/scheduler/ReportIssueCleanupScheduler.java
@@ -1,0 +1,21 @@
+package com.shinhan.esg_be.domain.report.scheduler;
+
+import com.shinhan.esg_be.domain.report.service.ReportIssueCleanupService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ReportIssueCleanupScheduler {
+
+    private final ReportIssueCleanupService reportIssueCleanupService;
+
+    @Scheduled(cron = "0 0 0 * * *", zone = "Asia/Seoul")
+    public void deleteExpiredReportIssues() {
+        long deletedCount = reportIssueCleanupService.deleteExpiredIssues();
+        log.info("Deleted {} expired report issues.", deletedCount);
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/service/MyReportService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/service/MyReportService.java
@@ -1,0 +1,145 @@
+package com.shinhan.esg_be.domain.report.service;
+
+import com.shinhan.esg_be.domain.policy.entity.EsgScorePolicy;
+import com.shinhan.esg_be.domain.policy.repository.EsgScorePolicyRepository;
+import com.shinhan.esg_be.domain.report.entity.enums.ReportPeriodType;
+import com.shinhan.esg_be.domain.report.dto.response.ReportCategorySummaryResponse;
+import com.shinhan.esg_be.domain.report.dto.response.ReportCertificateSnapshotResponse;
+import com.shinhan.esg_be.domain.report.dto.response.ReportPreviewResponse;
+import com.shinhan.esg_be.domain.report.repository.ReportQueryRepository;
+import com.shinhan.esg_be.domain.stat.entity.UserMonthlyStat;
+import com.shinhan.esg_be.domain.stat.repository.UserMonthlyStatRepository;
+import com.shinhan.esg_be.domain.user.entity.User;
+import com.shinhan.esg_be.domain.user.repository.UserRepository;
+import com.shinhan.esg_be.global.common.enums.ScoreCategory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.time.Clock;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class MyReportService {
+
+    private static final List<ScoreCategory> MONTHLY_TARGET_CATEGORIES = List.of(
+            ScoreCategory.E,
+            ScoreCategory.S,
+            ScoreCategory.G_ACTIVITY
+    );
+
+    private final UserRepository userRepository;
+    private final UserMonthlyStatRepository userMonthlyStatRepository;
+    private final EsgScorePolicyRepository esgScorePolicyRepository;
+    private final ReportQueryRepository reportQueryRepository;
+    private final Clock clock;
+
+    public ReportPreviewResponse getPreview(Long userId, String periodTypeCode) {
+        return new ReportPreviewResponse(getPreviewSnapshot(userId, periodTypeCode));
+    }
+
+    public ReportCertificateSnapshotResponse getPreviewSnapshot(Long userId, String periodTypeCode) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "User not found."));
+
+        ReportPeriodType periodType = ReportPeriodType.from(periodTypeCode);
+        LocalDate referenceDate = LocalDate.now(clock);
+        LocalDateTime from = periodType.startDateTime(referenceDate);
+        LocalDateTime to = periodType.endDateTime(referenceDate);
+        LocalDate requestedStartDate = from.toLocalDate();
+        LocalDate firstActivityDate = reportQueryRepository.findFirstActivityDate(userId);
+        LocalDate targetStartDate = firstActivityDate != null && firstActivityDate.isAfter(requestedStartDate)
+                ? firstActivityDate
+                : requestedStartDate;
+
+        long environmentActivityCount = reportQueryRepository.countApprovedEnvironmentActivities(userId, from, to);
+        long completedVolunteerCount = reportQueryRepository.countCompletedVolunteerActivities(userId, from, to);
+        int completedVolunteerHours = reportQueryRepository.sumCompletedVolunteerHours(userId, from, to);
+        long donationCount = reportQueryRepository.countDonations(userId, from, to);
+        long ecoProductPurchaseCount = reportQueryRepository.countEcoProductPurchases(userId, from, to);
+        long quizActivityCount = reportQueryRepository.countQuizActivities(userId, from, to);
+
+        ConsecutiveAchievementBadgeSummary badgeSummary = buildConsecutiveAchievementBadgeSummary(user);
+
+        return new ReportCertificateSnapshotResponse(
+                user.getName(),
+                periodType.code(),
+                periodType.label(),
+                referenceDate,
+                targetStartDate,
+                referenceDate,
+                user.getCurrentGrade(),
+                user.getTotalScore(),
+                Math.toIntExact(
+                        environmentActivityCount
+                                + completedVolunteerCount
+                                + donationCount
+                                + ecoProductPurchaseCount
+                                + quizActivityCount
+                ),
+                badgeSummary.consecutiveMonths(),
+                badgeSummary.visible(),
+                List.of(
+                        new ReportCategorySummaryResponse("ENVIRONMENT", "환경 활동(E)", Math.toIntExact(environmentActivityCount), "건"),
+                        new ReportCategorySummaryResponse("VOLUNTEER", "봉사활동(S)", completedVolunteerHours, "시간"),
+                        new ReportCategorySummaryResponse("DONATION", "사회공헌 활동(S)", Math.toIntExact(donationCount), "건"),
+                        new ReportCategorySummaryResponse("TRUST", "신뢰 활동(G)", Math.toIntExact(quizActivityCount), "건")
+                )
+        );
+    }
+
+    private ConsecutiveAchievementBadgeSummary buildConsecutiveAchievementBadgeSummary(User user) {
+        UserMonthlyStat userMonthlyStat = userMonthlyStatRepository.findByUser(user)
+                .orElse(null);
+        if (userMonthlyStat == null) {
+            return new ConsecutiveAchievementBadgeSummary(0, false);
+        }
+
+        Map<ScoreCategory, Integer> monthlyMaxScoreByCategory = loadMonthlyMaxScoreByCategory();
+        boolean achievedAllMonthlyTargets = MONTHLY_TARGET_CATEGORIES.stream()
+                .allMatch(category -> userMonthlyStat.getMonthlyScore(category) >= monthlyMaxScoreByCategory.get(category));
+
+        if (!achievedAllMonthlyTargets) {
+            return new ConsecutiveAchievementBadgeSummary(0, false);
+        }
+
+        int consecutiveMonths = Math.min(
+                userMonthlyStat.getConsecutiveEMaxScore(),
+                Math.min(
+                        userMonthlyStat.getConsecutiveSMaxScore(),
+                        userMonthlyStat.getConsecutiveGMaxScore()
+                )
+        ) + 1;
+
+        return new ConsecutiveAchievementBadgeSummary(consecutiveMonths, consecutiveMonths > 0);
+    }
+
+    private Map<ScoreCategory, Integer> loadMonthlyMaxScoreByCategory() {
+        Map<ScoreCategory, Integer> monthlyMaxScoreByCategory = new HashMap<>();
+        for (ScoreCategory category : MONTHLY_TARGET_CATEGORIES) {
+            EsgScorePolicy policy = esgScorePolicyRepository.findByCategoryAndIsActiveTrue(category)
+                    .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "ESG score policy not found."));
+            monthlyMaxScoreByCategory.put(category, defaultIfNull(policy.getMonthlyMaxScore()));
+        }
+        return monthlyMaxScoreByCategory;
+    }
+
+    private int defaultIfNull(Integer value) {
+        return value == null ? 0 : value;
+    }
+
+    private record ConsecutiveAchievementBadgeSummary(
+            Integer consecutiveMonths,
+            Boolean visible
+    ) {
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/service/ReportIssueCleanupService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/service/ReportIssueCleanupService.java
@@ -1,0 +1,23 @@
+package com.shinhan.esg_be.domain.report.service;
+
+import com.shinhan.esg_be.domain.report.repository.ReportIssueRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Clock;
+import java.time.LocalDateTime;
+
+@Service
+@RequiredArgsConstructor
+public class ReportIssueCleanupService {
+
+    private final ReportIssueRepository reportIssueRepository;
+    private final Clock clock;
+
+    @Transactional
+    public long deleteExpiredIssues() {
+        LocalDateTime cutoff = LocalDateTime.now(clock).minusMonths(1);
+        return reportIssueRepository.deleteByIssuedAtBefore(cutoff);
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/service/ReportIssueService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/service/ReportIssueService.java
@@ -1,0 +1,129 @@
+package com.shinhan.esg_be.domain.report.service;
+
+import com.shinhan.esg_be.domain.report.dto.request.ReportIssueRequest;
+import com.shinhan.esg_be.domain.report.dto.response.ReportCertificateMetaResponse;
+import com.shinhan.esg_be.domain.report.dto.response.ReportCertificateSnapshotResponse;
+import com.shinhan.esg_be.domain.report.dto.response.ReportIssueResponse;
+import com.shinhan.esg_be.domain.report.entity.ReportIssue;
+import com.shinhan.esg_be.domain.report.repository.ReportIssueRepository;
+import com.shinhan.esg_be.domain.user.entity.User;
+import com.shinhan.esg_be.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.security.SecureRandom;
+import java.time.Clock;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+@Transactional
+public class ReportIssueService {
+
+    private static final DateTimeFormatter CERTIFICATE_DATE_FORMATTER = DateTimeFormatter.ofPattern("yyMMdd");
+    private static final String VERIFY_PATH_PREFIX = "/report/verify/";
+    private final UserRepository userRepository;
+    private final ReportIssueRepository reportIssueRepository;
+    private final MyReportService myReportService;
+    private final Clock clock;
+    private final SecureRandom secureRandom = new SecureRandom();
+
+    public ReportIssueResponse issue(Long userId, ReportIssueRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "User not found."));
+
+        ReportCertificateSnapshotResponse snapshot = myReportService.getPreviewSnapshot(userId, request.periodType());
+        LocalDateTime issuedAt = LocalDateTime.now(clock);
+
+        ReportIssue reportIssue = reportIssueRepository.save(
+                ReportIssue.create(
+                        user,
+                        snapshot.periodType(),
+                        generateCertificateNumber(issuedAt),
+                        generateVerificationCode(),
+                        generateVerificationToken(),
+                        issuedAt,
+                        snapshot.targetStartDate(),
+                        snapshot.targetEndDate(),
+                        snapshot.recipientName(),
+                        snapshot.currentGrade().name(),
+                        snapshot.totalScore(),
+                        snapshot.verifiedActivityCount(),
+                        snapshot.consecutiveMaxAchievementMonths(),
+                        snapshot.showConsecutiveAchievementBadge(),
+                        getCategoryValue(snapshot, "ENVIRONMENT"),
+                        getCategoryValue(snapshot, "VOLUNTEER"),
+                        getCategoryValue(snapshot, "DONATION"),
+                        getCategoryValue(snapshot, "TRUST")
+                )
+        );
+
+        return new ReportIssueResponse(
+                toCertificateMeta(reportIssue),
+                snapshot
+        );
+    }
+
+    private int getCategoryValue(ReportCertificateSnapshotResponse snapshot, String categoryKey) {
+        return snapshot.categories().stream()
+                .filter(category -> categoryKey.equals(category.categoryKey()))
+                .findFirst()
+                .map(category -> category.value())
+                .orElse(0);
+    }
+
+    private String generateCertificateNumber(LocalDateTime issuedAt) {
+        String datePart = issuedAt.format(CERTIFICATE_DATE_FORMATTER);
+        String candidate;
+        do {
+            candidate = "ESG-" + datePart + "-" + String.format("%04d", secureRandom.nextInt(10_000));
+        } while (reportIssueRepository.existsByCertificateNumber(candidate));
+
+        return candidate;
+    }
+
+    private String generateVerificationCode() {
+        String candidate;
+        do {
+            candidate = "QR-" + randomAlphaNumeric(4) + "-" + randomAlphaNumeric(2);
+        } while (reportIssueRepository.existsByVerificationCode(candidate));
+
+        return candidate;
+    }
+
+    private String generateVerificationToken() {
+        String candidate;
+        do {
+            byte[] bytes = new byte[24];
+            secureRandom.nextBytes(bytes);
+            candidate = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes);
+        } while (reportIssueRepository.existsByVerificationToken(candidate));
+
+        return candidate;
+    }
+
+    private String randomAlphaNumeric(int length) {
+        final char[] source = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789".toCharArray();
+        StringBuilder builder = new StringBuilder(length);
+        for (int index = 0; index < length; index++) {
+            builder.append(source[secureRandom.nextInt(source.length)]);
+        }
+        return builder.toString();
+    }
+
+    private ReportCertificateMetaResponse toCertificateMeta(ReportIssue reportIssue) {
+        return new ReportCertificateMetaResponse(
+                reportIssue.getReportIssueId(),
+                reportIssue.getCertificateNumber(),
+                reportIssue.getVerificationCode(),
+                VERIFY_PATH_PREFIX + reportIssue.getVerificationToken(),
+                reportIssue.getIssuedAt()
+        );
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/service/ReportPdfService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/service/ReportPdfService.java
@@ -1,0 +1,247 @@
+package com.shinhan.esg_be.domain.report.service;
+
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.EncodeHintType;
+import com.google.zxing.MultiFormatWriter;
+import com.google.zxing.WriterException;
+import com.google.zxing.client.j2se.MatrixToImageWriter;
+import com.google.zxing.common.BitMatrix;
+import com.openhtmltopdf.pdfboxout.PdfRendererBuilder;
+import com.shinhan.esg_be.domain.report.dto.response.ReportPdfFile;
+import com.shinhan.esg_be.domain.report.entity.ReportIssue;
+import com.shinhan.esg_be.domain.report.repository.ReportIssueRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StreamUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+import javax.imageio.ImageIO;
+import java.awt.AlphaComposite;
+import java.awt.Graphics2D;
+import java.awt.image.BufferedImage;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.format.DateTimeFormatter;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportPdfService {
+
+    private static final String TEMPLATE_PATH = "templates/report/certificate-template.html";
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyy.MM.dd");
+    private static final List<Path> FONT_CANDIDATES = List.of(
+            Path.of("C:/Windows/Fonts/NanumGothic.ttf"),
+            Path.of("C:/Windows/Fonts/malgun.ttf"),
+            Path.of("/usr/share/fonts/truetype/nanum/NanumGothic.ttf"),
+            Path.of("/usr/share/fonts/truetype/malgun/malgun.ttf")
+    );
+
+    private final ReportIssueRepository reportIssueRepository;
+
+    @Value("${app.report-verification-base-url:http://localhost:5173}")
+    private String reportVerificationBaseUrl;
+
+    @Value("${app.report-watermark-image-url:https://solve-s3-storage.s3.ap-northeast-2.amazonaws.com/verified.webp}")
+    private String reportWatermarkImageUrl;
+
+    public ReportPdfFile download(Long userId, Long issueId) {
+        ReportIssue reportIssue = reportIssueRepository.findByReportIssueIdAndUser_UserId(issueId, userId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Report issue not found."));
+
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            String html = buildHtml(reportIssue);
+            renderPdf(html, outputStream);
+
+            return new ReportPdfFile(
+                    "ESG_certificate_" + reportIssue.getCertificateNumber() + ".pdf",
+                    outputStream.toByteArray()
+            );
+        } catch (IOException | WriterException exception) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Failed to generate report pdf.", exception);
+        }
+    }
+
+    private void renderPdf(String html, ByteArrayOutputStream outputStream) throws IOException {
+        Path fontPath = resolveFontPath();
+
+        PdfRendererBuilder builder = new PdfRendererBuilder();
+        builder.useFastMode();
+        builder.withHtmlContent(html, null);
+        builder.toStream(outputStream);
+        builder.useFont(fontPath.toFile(), "ReportKoreanFont");
+        builder.run();
+    }
+
+    private String buildHtml(ReportIssue reportIssue) throws IOException, WriterException {
+        String template = loadTemplate();
+        String verificationUrl = buildVerificationUrl(reportIssue);
+        String watermarkImageDataUrl = buildWatermarkImageDataUrl();
+
+        return replacePlaceholders(
+                template,
+                Map.ofEntries(
+                        Map.entry("ISSUED_AT", escapeHtml(DATE_FORMATTER.format(reportIssue.getIssuedAt().toLocalDate()))),
+                        Map.entry("RECIPIENT_NAME", escapeHtml(reportIssue.getRecipientName())),
+                        Map.entry("GRADE_LABEL", escapeHtml(resolveGradeLabel(reportIssue.getGrade()))),
+                        Map.entry("TOTAL_SCORE", escapeHtml(reportIssue.getTotalScore() + "점")),
+                        Map.entry("VERIFIED_ACTIVITY_COUNT", escapeHtml(reportIssue.getVerifiedActivityCount() + "건")),
+                        Map.entry("CONSECUTIVE_ACTIVITY", escapeHtml(resolveConsecutiveLabel(reportIssue))),
+                        Map.entry("TARGET_PERIOD", escapeHtml(
+                                DATE_FORMATTER.format(reportIssue.getTargetStartDate())
+                                        + " ~ "
+                                        + DATE_FORMATTER.format(reportIssue.getTargetEndDate())
+                        )),
+                        Map.entry("ISSUER", "SOLVE"),
+                        Map.entry("CERTIFICATE_NUMBER", escapeHtml(reportIssue.getCertificateNumber())),
+                        Map.entry("ENVIRONMENT_ACTIVITY", escapeHtml(reportIssue.getEnvironmentActivityCount() + "건")),
+                        Map.entry("VOLUNTEER_ACTIVITY", escapeHtml(reportIssue.getVolunteerHours() + "시간")),
+                        Map.entry("SOCIAL_CONTRIBUTION_ACTIVITY", escapeHtml(reportIssue.getSocialContributionCount() + "건")),
+                        Map.entry("TRUST_ACTIVITY", escapeHtml(reportIssue.getTrustActivityCount() + "건")),
+                        Map.entry("VERIFICATION_CODE", escapeHtml(reportIssue.getVerificationCode())),
+                        Map.entry("VERIFICATION_URL", escapeHtml(verificationUrl)),
+                        Map.entry("VERIFICATION_URL_HREF", escapeHtmlAttribute(verificationUrl)),
+                        Map.entry("QR_IMAGE_DATA_URL", buildQrImageDataUrl(verificationUrl)),
+                        Map.entry("WATERMARK_BACKGROUND_STYLE", buildWatermarkBackgroundStyle(watermarkImageDataUrl))
+                )
+        );
+    }
+
+    private String loadTemplate() throws IOException {
+        ClassPathResource templateResource = new ClassPathResource(TEMPLATE_PATH);
+        try (InputStream inputStream = templateResource.getInputStream()) {
+            return StreamUtils.copyToString(inputStream, StandardCharsets.UTF_8);
+        }
+    }
+
+    private String replacePlaceholders(String template, Map<String, String> values) {
+        String rendered = template;
+        for (Map.Entry<String, String> entry : values.entrySet()) {
+            rendered = rendered.replace("{{" + entry.getKey() + "}}", entry.getValue());
+        }
+        return rendered;
+    }
+
+    private Path resolveFontPath() throws IOException {
+        for (Path candidate : FONT_CANDIDATES) {
+            if (Files.exists(candidate)) {
+                return candidate;
+            }
+        }
+        throw new IOException("No Korean font file found for report pdf generation.");
+    }
+
+    private String buildQrImageDataUrl(String verificationUrl) throws WriterException, IOException {
+        BufferedImage qrImage = createQrImage(verificationUrl);
+        try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            ImageIO.write(qrImage, "png", outputStream);
+            String base64 = Base64.getEncoder().encodeToString(outputStream.toByteArray());
+            return "data:image/png;base64," + base64;
+        }
+    }
+
+    private String buildWatermarkImageDataUrl() {
+        try (InputStream inputStream = new URL(reportWatermarkImageUrl).openStream();
+             ByteArrayOutputStream outputStream = new ByteArrayOutputStream()) {
+            BufferedImage watermarkImage = ImageIO.read(inputStream);
+            if (watermarkImage == null) {
+                return "";
+            }
+
+            BufferedImage transparentWatermark = new BufferedImage(
+                    watermarkImage.getWidth(),
+                    watermarkImage.getHeight(),
+                    BufferedImage.TYPE_INT_ARGB
+            );
+            Graphics2D graphics = transparentWatermark.createGraphics();
+            graphics.setComposite(AlphaComposite.getInstance(AlphaComposite.SRC_OVER, 0.07f));
+            graphics.drawImage(watermarkImage, 0, 0, null);
+            graphics.dispose();
+
+            ImageIO.write(transparentWatermark, "png", outputStream);
+            String base64 = Base64.getEncoder().encodeToString(outputStream.toByteArray());
+            return "data:image/png;base64," + base64;
+        } catch (IOException exception) {
+            return "";
+        }
+    }
+
+    private String buildWatermarkBackgroundStyle(String watermarkImageDataUrl) {
+        if (watermarkImageDataUrl.isBlank()) {
+            return "";
+        }
+
+        return "background-image: url('" + escapeHtmlAttribute(watermarkImageDataUrl) + "');"
+                + " background-repeat: no-repeat;"
+                + " background-position: center center;"
+                + " background-size: 500px auto;";
+    }
+
+    private BufferedImage createQrImage(String verificationUrl) throws WriterException {
+        Map<EncodeHintType, Object> hints = Map.of(EncodeHintType.MARGIN, 1);
+        BitMatrix matrix = new MultiFormatWriter().encode(
+                verificationUrl,
+                BarcodeFormat.QR_CODE,
+                220,
+                220,
+                hints
+        );
+        return MatrixToImageWriter.toBufferedImage(matrix);
+    }
+
+    private String buildVerificationUrl(ReportIssue reportIssue) {
+        String normalizedBaseUrl = reportVerificationBaseUrl.endsWith("/")
+                ? reportVerificationBaseUrl.substring(0, reportVerificationBaseUrl.length() - 1)
+                : reportVerificationBaseUrl;
+        return normalizedBaseUrl + "/report/verify/" + reportIssue.getVerificationToken();
+    }
+
+    private String resolveConsecutiveLabel(ReportIssue reportIssue) {
+        if (!Boolean.TRUE.equals(reportIssue.getShowConsecutiveAchievementBadge())
+                || reportIssue.getConsecutiveMaxAchievementMonths() == null
+                || reportIssue.getConsecutiveMaxAchievementMonths() <= 0) {
+            return "-";
+        }
+        return reportIssue.getConsecutiveMaxAchievementMonths() + "개월";
+    }
+
+    private String resolveGradeLabel(String grade) {
+        return switch (grade) {
+            case "SEED" -> "씨앗";
+            case "SPROUT" -> "새싹";
+            case "TREE" -> "나무";
+            case "FOREST" -> "숲";
+            case "EARTH" -> "지구";
+            default -> grade;
+        };
+    }
+
+    private String escapeHtml(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        return value
+                .replace("&", "&amp;")
+                .replace("<", "&lt;")
+                .replace(">", "&gt;")
+                .replace("\"", "&quot;")
+                .replace("'", "&#39;");
+    }
+
+    private String escapeHtmlAttribute(String value) {
+        return escapeHtml(value);
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/report/service/ReportVerificationService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/report/service/ReportVerificationService.java
@@ -1,0 +1,75 @@
+package com.shinhan.esg_be.domain.report.service;
+
+import com.shinhan.esg_be.domain.report.dto.response.ReportCategorySummaryResponse;
+import com.shinhan.esg_be.domain.report.dto.response.ReportCertificateMetaResponse;
+import com.shinhan.esg_be.domain.report.dto.response.ReportCertificateSnapshotResponse;
+import com.shinhan.esg_be.domain.report.dto.response.ReportVerificationResponse;
+import com.shinhan.esg_be.domain.report.entity.ReportIssue;
+import com.shinhan.esg_be.domain.report.repository.ReportIssueRepository;
+import com.shinhan.esg_be.domain.user.entity.enums.Grade;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ReportVerificationService {
+
+    private static final String VERIFY_PATH_PREFIX = "/report/verify/";
+    private final ReportIssueRepository reportIssueRepository;
+
+    public ReportVerificationResponse verify(String token) {
+        return reportIssueRepository.findByVerificationToken(token)
+                .map(this::toVerificationResponse)
+                .orElseGet(() -> new ReportVerificationResponse(false, "INVALID", null, null));
+    }
+
+    private ReportVerificationResponse toVerificationResponse(ReportIssue reportIssue) {
+        boolean valid = reportIssue.getStatus() == ReportIssue.ReportIssueStatus.ACTIVE;
+        String verificationStatus = valid ? "ACTIVE" : "REVOKED";
+
+        return new ReportVerificationResponse(
+                valid,
+                verificationStatus,
+                new ReportCertificateMetaResponse(
+                        reportIssue.getReportIssueId(),
+                        reportIssue.getCertificateNumber(),
+                        reportIssue.getVerificationCode(),
+                        VERIFY_PATH_PREFIX + reportIssue.getVerificationToken(),
+                        reportIssue.getIssuedAt()
+                ),
+                new ReportCertificateSnapshotResponse(
+                        reportIssue.getRecipientName(),
+                        reportIssue.getPeriodType(),
+                        resolvePeriodLabel(reportIssue.getPeriodType()),
+                        reportIssue.getIssuedAt().toLocalDate(),
+                        reportIssue.getTargetStartDate(),
+                        reportIssue.getTargetEndDate(),
+                        Grade.valueOf(reportIssue.getGrade()),
+                        reportIssue.getTotalScore(),
+                        reportIssue.getVerifiedActivityCount(),
+                        reportIssue.getConsecutiveMaxAchievementMonths(),
+                        reportIssue.getShowConsecutiveAchievementBadge(),
+                        List.of(
+                                new ReportCategorySummaryResponse("ENVIRONMENT", "환경 활동(E)", reportIssue.getEnvironmentActivityCount(), "건"),
+                                new ReportCategorySummaryResponse("VOLUNTEER", "봉사활동(S)", reportIssue.getVolunteerHours(), "시간"),
+                                new ReportCategorySummaryResponse("DONATION", "사회공헌 활동(S)", reportIssue.getSocialContributionCount(), "건"),
+                                new ReportCategorySummaryResponse("TRUST", "신뢰 활동(G)", reportIssue.getTrustActivityCount(), "건")
+                        )
+                )
+        );
+    }
+
+    private String resolvePeriodLabel(String periodType) {
+        return switch (periodType) {
+            case "1M" -> "최근 1개월";
+            case "3M" -> "최근 3개월";
+            case "6M" -> "최근 6개월";
+            case "1Y" -> "최근 1년";
+            default -> periodType;
+        };
+    }
+}

--- a/src/main/resources/templates/report/certificate-template.html
+++ b/src/main/resources/templates/report/certificate-template.html
@@ -1,0 +1,400 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+    <meta charset="UTF-8" />
+    <style>
+        @page {
+            size: A4;
+            margin: 10mm 12mm;
+        }
+
+        * {
+            box-sizing: border-box;
+        }
+
+        body {
+            margin: 0;
+            font-family: "ReportKoreanFont", sans-serif;
+            color: #111827;
+            background: #ffffff;
+            font-size: 12px;
+            line-height: 1.45;
+        }
+
+        .certificate-layout {
+            width: 100%;
+            height: 272mm;
+            table-layout: fixed;
+            border-collapse: separate;
+            border-spacing: 0;
+            background-color: #ffffff;
+        }
+
+        .header-row {
+            height: 24mm;
+        }
+
+        .content-row {
+            height: 176mm;
+        }
+
+        .footer-row {
+            height: 30mm;
+        }
+
+        .header-cell {
+            padding: 16px 24px 10px;
+            border-bottom: 1px solid #eef2f7;
+        }
+
+        .title {
+            margin: 0;
+            text-align: center;
+            font-size: 26px;
+            font-weight: 700;
+            letter-spacing: -0.03em;
+        }
+
+        .issued-at {
+            margin-top: 8px;
+            text-align: right;
+            font-size: 11px;
+            color: #9ca3af;
+            font-weight: 500;
+        }
+
+        .content-cell {
+            padding: 10px 24px 6px;
+            vertical-align: top;
+        }
+
+        .content-layout {
+            width: 100%;
+            height: 176mm;
+            table-layout: fixed;
+            border-collapse: collapse;
+        }
+
+        .content-layout td {
+            vertical-align: top;
+        }
+
+        .recipient-row {
+            height: 44mm;
+        }
+
+        .summary-row {
+            height: 44mm;
+        }
+
+        .meta-row {
+            height: 44mm;
+        }
+
+        .category-row {
+            height: 44mm;
+        }
+
+        .content-section {
+            height: 100%;
+            padding: 4px 0;
+        }
+
+        .recipient-label {
+            margin: 0;
+            font-size: 11px;
+            color: #9ca3af;
+            font-weight: 500;
+        }
+
+        .recipient-name {
+            margin: 8px 0 0;
+            font-size: 22px;
+            font-weight: 700;
+            letter-spacing: -0.03em;
+        }
+
+        .summary-table,
+        .meta-table,
+        .category-table,
+        .verification-table,
+        .verification-inner {
+            width: 100%;
+            border-collapse: collapse;
+        }
+
+        .summary-table {
+            border: 1px solid #e5e7eb;
+        }
+
+        .summary-table td {
+            width: 50%;
+            padding: 14px 16px;
+            border: 1px solid #eef2f7;
+            vertical-align: top;
+        }
+
+        .summary-label {
+            margin: 0;
+            font-size: 11px;
+            color: #9ca3af;
+            font-weight: 500;
+        }
+
+        .summary-value {
+            margin: 6px 0 0;
+            font-size: 16px;
+            font-weight: 700;
+            color: #111827;
+        }
+
+        .summary-section,
+        .meta-section,
+        .category-section {
+            height: 100%;
+        }
+
+        .summary-section,
+        .meta-section,
+        .category-section {
+            border-top: 1px solid #eef2f7;
+            padding-top: 10px;
+        }
+
+        .meta-table td,
+        .category-table td {
+            padding: 7px 0;
+            vertical-align: top;
+        }
+
+        .meta-label {
+            width: 96px;
+            color: #6b7280;
+            font-weight: 500;
+        }
+
+        .meta-value {
+            text-align: right;
+            color: #111827;
+            font-weight: 600;
+        }
+
+        .section-title {
+            margin: 0 0 10px;
+            font-size: 13px;
+            color: #9ca3af;
+            font-weight: 500;
+        }
+
+        .category-label-cell {
+            color: #111827;
+            font-weight: 500;
+            padding-right: 12px;
+        }
+
+        .category-value-cell {
+            width: 96px;
+            text-align: right;
+            color: #111827;
+            font-weight: 700;
+        }
+
+        .footer-cell {
+            padding: 6px 24px 4px;
+            vertical-align: bottom;
+            border-top: 1px dashed #d1d5db;
+            background: #f7fbff;
+        }
+
+        .verification-left {
+            width: 80%;
+            padding-right: 14px;
+            vertical-align: top;
+        }
+
+        .verification-right {
+            width: 20%;
+            text-align: right;
+            vertical-align: middle;
+        }
+
+        .verification-inner td {
+            padding: 2px 0;
+            vertical-align: top;
+        }
+
+        .verification-label {
+            width: 78px;
+            color: #6b7280;
+            font-size: 11px;
+            font-weight: 500;
+        }
+
+        .verification-value {
+            text-align: right;
+            color: #111827;
+            font-size: 11px;
+            font-weight: 600;
+            word-break: break-all;
+        }
+
+        .verification-link {
+            color: #111827;
+            text-decoration: none;
+        }
+
+        .qr-box {
+            display: inline-block;
+            width: 72px;
+            padding: 5px;
+            border: 1px solid #d1d5db;
+            border-radius: 14px;
+            background: #ffffff;
+            text-align: center;
+        }
+
+        .qr-box img {
+            display: block;
+            width: 56px;
+            height: 56px;
+            margin: 0 auto;
+        }
+
+        .qr-caption {
+            margin-top: 6px;
+            font-size: 10px;
+            color: #6b7280;
+            font-weight: 600;
+        }
+    </style>
+</head>
+<body>
+<table class="certificate-layout" style="{{WATERMARK_BACKGROUND_STYLE}}">
+    <tr class="header-row">
+        <td class="header-cell">
+            <h1 class="title">ESG 활동 인증서</h1>
+            <div class="issued-at">발급일 {{ISSUED_AT}}</div>
+        </td>
+    </tr>
+    <tr class="content-row">
+        <td class="content-cell">
+            <table class="content-layout">
+                <tr class="recipient-row">
+                    <td>
+                        <div class="content-section recipient-section">
+                            <p class="recipient-label">발급 대상</p>
+                            <p class="recipient-name">{{RECIPIENT_NAME}}</p>
+                        </div>
+                    </td>
+                </tr>
+                <tr class="summary-row">
+                    <td>
+                        <div class="content-section summary-section">
+                            <table class="summary-table" aria-hidden="true">
+                                <tr>
+                                    <td>
+                                        <p class="summary-label">ESG 등급</p>
+                                        <p class="summary-value">{{GRADE_LABEL}}</p>
+                                    </td>
+                                    <td>
+                                        <p class="summary-label">ESG 점수</p>
+                                        <p class="summary-value">{{TOTAL_SCORE}}</p>
+                                    </td>
+                                </tr>
+                                <tr>
+                                    <td>
+                                        <p class="summary-label">인증 활동</p>
+                                        <p class="summary-value">{{VERIFIED_ACTIVITY_COUNT}}</p>
+                                    </td>
+                                    <td>
+                                        <p class="summary-label">연속 활동</p>
+                                        <p class="summary-value">{{CONSECUTIVE_ACTIVITY}}</p>
+                                    </td>
+                                </tr>
+                            </table>
+                        </div>
+                    </td>
+                </tr>
+                <tr class="meta-row">
+                    <td>
+                        <div class="content-section meta-section">
+                            <table class="meta-table">
+                                <tr>
+                                    <td class="meta-label">대상 기간</td>
+                                    <td class="meta-value">{{TARGET_PERIOD}}</td>
+                                </tr>
+                                <tr>
+                                    <td class="meta-label">발급기관</td>
+                                    <td class="meta-value">{{ISSUER}}</td>
+                                </tr>
+                                <tr>
+                                    <td class="meta-label">인증서 번호</td>
+                                    <td class="meta-value">{{CERTIFICATE_NUMBER}}</td>
+                                </tr>
+                            </table>
+                        </div>
+                    </td>
+                </tr>
+                <tr class="category-row">
+                    <td>
+                        <div class="content-section category-section">
+                            <p class="section-title">카테고리 요약</p>
+                            <table class="category-table">
+                                <tr>
+                                    <td class="category-label-cell">환경 활동(E)</td>
+                                    <td class="category-value-cell">{{ENVIRONMENT_ACTIVITY}}</td>
+                                </tr>
+                                <tr>
+                                    <td class="category-label-cell">봉사활동(S)</td>
+                                    <td class="category-value-cell">{{VOLUNTEER_ACTIVITY}}</td>
+                                </tr>
+                                <tr>
+                                    <td class="category-label-cell">사회공헌 활동(S)</td>
+                                    <td class="category-value-cell">{{SOCIAL_CONTRIBUTION_ACTIVITY}}</td>
+                                </tr>
+                                <tr>
+                                    <td class="category-label-cell">신뢰 활동(G)</td>
+                                    <td class="category-value-cell">{{TRUST_ACTIVITY}}</td>
+                                </tr>
+                            </table>
+                        </div>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+    <tr class="footer-row">
+        <td class="footer-cell">
+            <table class="verification-table">
+                <tr>
+                    <td class="verification-left">
+                        <table class="verification-inner">
+                            <tr>
+                                <td class="verification-label">인증 코드</td>
+                                <td class="verification-value">{{VERIFICATION_CODE}}</td>
+                            </tr>
+                            <tr>
+                                <td class="verification-label">인증 URL</td>
+                                <td class="verification-value">
+                                    <a class="verification-link" href="{{VERIFICATION_URL_HREF}}">{{VERIFICATION_URL}}</a>
+                                </td>
+                            </tr>
+                            <tr>
+                                <td class="verification-label">유효 기간</td>
+                                <td class="verification-value">발급일로부터 1개월</td>
+                            </tr>
+                        </table>
+                    </td>
+                    <td class="verification-right">
+                        <div class="qr-box">
+                            <img src="{{QR_IMAGE_DATA_URL}}" alt="인증서 검증 QR 코드" />
+                            <div class="qr-caption">QR 코드</div>
+                        </div>
+                    </td>
+                </tr>
+            </table>
+        </td>
+    </tr>
+</table>
+</body>
+</html>


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #67

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- ESG 활동 인증서 조회, 발급, 검증 기능 구현
- 인증서 PDF 다운로드 및 만료 데이터 자동 삭제 기능 구현

## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->
- report 도메인 추가 및 인증서 미리보기/발급/검증 API 구현
- report_issue 엔티티, DTO, repository, service, controller 구조 추가
- 인증서 발급 시 인증서 번호, 인증 코드, 검증 토큰 생성 및 스냅샷 데이터 저장 로직 구현
- GET /api/my/reports/issues/{issueId}/pdf API 추가 및 인증서 PDF 생성 로직 구현
- PDF 생성을 위해 openhtmltopdf, zxing, imageio-webp 의존성 추가
- certificate-template.html 템플릿 기반 PDF 렌더링 및 QR/워터마크 반영 로직 구현
- GET /api/reports/verify/{token} 검증 API 구현 및 인증서 상태 응답 처리 구현
- 발급일 기준 1개월 지난 인증서 데이터를 매일 00:00에 삭제하는 스케줄러 추가

## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [x] 로컬에서 정상 동작 확인
- [x] API 테스트 완료 (해당되면)
- [x] 빌드 에러 없음

## 📸 스크린샷
<!-- UI 변경이 있으면 스크린샷 첨부 -->

## 💡 리뷰어에게
<!-- 리뷰할 때 중점적으로 봐줬으면 하는 부분 -->
