### PR TITLE
feat : ESG 활동 점수 일일 1회 제한 적용

### DIFF
--- a/src/main/java/com/shinhan/esg_be/domain/score/service/ScoreService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/score/service/ScoreService.java
@@ -93,6 +93,17 @@ public class ScoreService {
                 .orElseGet(() -> userMonthlyStatRepository.save(UserMonthlyStat.create(user)));
 
         LocalDateTime activityDateTime = resolveActivityDateTime(command.activityDateTime());
+        ScoreReason scoreReason = mapToScoreReason(command.activityType());
+        if (isDailyScoreLimited(command.activityType()) && alreadyAppliedDailyScore(user, scoreReason, activityDateTime)) {
+            return new ApplyActivityScoreResult(
+                    scoreCategory,
+                    0,
+                    user.getScore(scoreCategory),
+                    userMonthlyStat.getMonthlyScore(scoreCategory),
+                    false
+            );
+        }
+
         ScoreCalculationResult calculationResult = scoreCalculatorService.calculateActivity(
                 new ScoreCalculationCommand(
                         scoreCategory,
@@ -115,7 +126,7 @@ public class ScoreService {
                             user,
                             scoreCategory,
                             calculationResult.appliedScore(),
-                            mapToScoreReason(command.activityType()),
+                            scoreReason,
                             activityDateTime.plusYears(1),
                             calculationResult.newScore()
                     )
@@ -141,6 +152,24 @@ public class ScoreService {
 
     private LocalDateTime resolveActivityDateTime(LocalDateTime activityDateTime) {
         return activityDateTime == null ? LocalDateTime.now() : activityDateTime;
+    }
+
+    private boolean isDailyScoreLimited(ActivityType activityType) {
+        return switch (activityType) {
+            case DONATION, VOLUNTEER, PURCHASE, QUIZ_CORRECT, QUIZ_WRONG, PHOTO -> true;
+            case LOAN_REPAY -> false;
+        };
+    }
+
+    private boolean alreadyAppliedDailyScore(User user, ScoreReason scoreReason, LocalDateTime activityDateTime) {
+        LocalDateTime startOfDay = activityDateTime.toLocalDate().atStartOfDay();
+        LocalDateTime nextDay = startOfDay.plusDays(1);
+        return validScoreHistoryRepository.existsByUserAndReasonAndCreatedAtBetween(
+                user,
+                scoreReason,
+                startOfDay,
+                nextDay
+        );
     }
 
     private ScoreReason mapToScoreReason(ActivityType activityType) {

--- a/src/test/java/com/shinhan/esg_be/domain/reward/service/RewardServiceTest.java
+++ b/src/test/java/com/shinhan/esg_be/domain/reward/service/RewardServiceTest.java
@@ -63,6 +63,8 @@ class RewardServiceTest {
 
     @BeforeEach
     void setUp() {
+        userPointRepository.deleteAllInBatch();
+        validScoreHistoryRepository.deleteAllInBatch();
         activityRewardPolicyRepository.deleteAllInBatch();
         esgScorePolicyRepository.deleteAllInBatch();
     }
@@ -142,6 +144,52 @@ class RewardServiceTest {
         assertThat(scoreHistories).hasSize(1);
         assertThat(scoreHistories.get(0).getReason()).isEqualTo(ScoreReason.LOAN_REPAY);
         assertThat(userPoints).isEmpty();
+    }
+
+    @Test
+    @DisplayName("같은 날 동일 활동 보상은 점수를 1회만 부여하고 포인트는 계속 적립한다")
+    void applyPointEvenWhenDuplicateDailyScoreIsSkipped() {
+        User user = userRepository.save(createUser("reward-user-3", 50, 250, 100, 100, 0));
+        userMonthlyStatRepository.save(createUserMonthlyStat(user, 0, 0, 0));
+        activityRewardPolicyRepository.save(
+                createActivityRewardPolicy(ActivityType.DONATION, ScoreCategory.S, 20, null, new BigDecimal("0.03"))
+        );
+        esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.S, 500, 25, 3, 50, 250));
+
+        LocalDateTime activityDateTime = LocalDateTime.now();
+        ApplyActivityRewardResult firstResult = rewardService.applyActivityReward(
+                new ApplyActivityRewardCommand(
+                        user.getUserId(),
+                        ActivityType.DONATION,
+                        BigDecimal.valueOf(30000),
+                        activityDateTime
+                )
+        );
+        ApplyActivityRewardResult secondResult = rewardService.applyActivityReward(
+                new ApplyActivityRewardCommand(
+                        user.getUserId(),
+                        ActivityType.DONATION,
+                        BigDecimal.valueOf(30000),
+                        activityDateTime
+                )
+        );
+
+        User savedUser = userRepository.findById(user.getUserId()).orElseThrow();
+        UserMonthlyStat savedStat = userMonthlyStatRepository.findByUser(savedUser).orElseThrow();
+        List<ValidScoreHistory> scoreHistories = validScoreHistoryRepository.findAll();
+        List<UserPoint> userPoints = userPointRepository.findAll();
+
+        assertThat(firstResult.scoreResult().appliedScore()).isEqualTo(20);
+        assertThat(secondResult.scoreResult().appliedScore()).isZero();
+        assertThat(firstResult.pointResult().activityPoint()).isEqualTo(900);
+        assertThat(secondResult.pointResult().activityPoint()).isEqualTo(900);
+
+        assertThat(savedUser.getSScore()).isEqualTo(270);
+        assertThat(savedUser.getTotalPoints()).isEqualTo(1800);
+        assertThat(savedStat.getMonthlySScore()).isEqualTo(20);
+        assertThat(scoreHistories).hasSize(1);
+        assertThat(userPoints).hasSize(2);
+        assertThat(userPoints).allMatch(userPoint -> userPoint.getReason() == PointReason.DONATION);
     }
 
     private User createUser(

--- a/src/test/java/com/shinhan/esg_be/domain/score/service/ScoreServiceTest.java
+++ b/src/test/java/com/shinhan/esg_be/domain/score/service/ScoreServiceTest.java
@@ -58,6 +58,7 @@ class ScoreServiceTest {
 
     @BeforeEach
     void setUp() {
+        validScoreHistoryRepository.deleteAllInBatch();
         activityRewardPolicyRepository.deleteAllInBatch();
         esgScorePolicyRepository.deleteAllInBatch();
     }
@@ -173,6 +174,85 @@ class ScoreServiceTest {
         assertThat(scoreHistories).allMatch(history -> history.getReason() == ScoreReason.INITIAL_SCORE);
         assertThat(scoreHistories).extracting(ValidScoreHistory::getChangeAmount)
                 .containsExactly(50, 250, 100, 100);
+    }
+
+    @Test
+    @DisplayName("같은 날 동일 활동으로 이미 점수를 받았다면 추가 점수를 부여하지 않는다")
+    void doNotApplyDuplicateDailyActivityScore() {
+        User user = userRepository.save(createUser("score-user-5", 50, 250, 100, 100));
+        userMonthlyStatRepository.save(createUserMonthlyStat(user, 0, 0, 0));
+        activityRewardPolicyRepository.save(createActivityRewardPolicy(ActivityType.DONATION, ScoreCategory.S, 20));
+        esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.S, 500, 25, 3, 50, 250));
+
+        LocalDateTime activityDateTime = LocalDateTime.now();
+        ApplyActivityScoreResult firstResult = scoreService.applyActivityScore(
+                new ApplyActivityScoreCommand(
+                        user.getUserId(),
+                        ActivityType.DONATION,
+                        BigDecimal.valueOf(30000),
+                        activityDateTime
+                )
+        );
+        ApplyActivityScoreResult secondResult = scoreService.applyActivityScore(
+                new ApplyActivityScoreCommand(
+                        user.getUserId(),
+                        ActivityType.DONATION,
+                        BigDecimal.valueOf(30000),
+                        activityDateTime
+                )
+        );
+
+        User savedUser = userRepository.findById(user.getUserId()).orElseThrow();
+        UserMonthlyStat savedStat = userMonthlyStatRepository.findByUser(savedUser).orElseThrow();
+        List<ValidScoreHistory> scoreHistories = validScoreHistoryRepository.findAll();
+
+        assertThat(firstResult.appliedScore()).isEqualTo(20);
+        assertThat(secondResult.appliedScore()).isZero();
+        assertThat(secondResult.scoreAfter()).isEqualTo(270);
+        assertThat(savedUser.getSScore()).isEqualTo(270);
+        assertThat(savedStat.getMonthlySScore()).isEqualTo(20);
+        assertThat(scoreHistories).hasSize(1);
+        assertThat(scoreHistories.get(0).getReason()).isEqualTo(ScoreReason.DONATION);
+    }
+
+    @Test
+    @DisplayName("퀴즈 정답과 오답은 각각의 정책을 적용하지만 같은 날 점수는 1회만 부여한다")
+    void doNotApplyQuizScoreAgainAfterCorrectOrWrongScore() {
+        User user = userRepository.save(createUser("score-user-6", 50, 250, 100, 100));
+        userMonthlyStatRepository.save(createUserMonthlyStat(user, 0, 0, 0));
+        activityRewardPolicyRepository.save(createActivityRewardPolicy(ActivityType.QUIZ_CORRECT, ScoreCategory.G_ACTIVITY, 2));
+        activityRewardPolicyRepository.save(createActivityRewardPolicy(ActivityType.QUIZ_WRONG, ScoreCategory.G_ACTIVITY, 1));
+        esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.G_ACTIVITY, 200, 10, 3, 20, 100));
+
+        LocalDateTime activityDateTime = LocalDateTime.now();
+        ApplyActivityScoreResult correctResult = scoreService.applyActivityScore(
+                new ApplyActivityScoreCommand(
+                        user.getUserId(),
+                        ActivityType.QUIZ_CORRECT,
+                        null,
+                        activityDateTime
+                )
+        );
+        ApplyActivityScoreResult wrongResult = scoreService.applyActivityScore(
+                new ApplyActivityScoreCommand(
+                        user.getUserId(),
+                        ActivityType.QUIZ_WRONG,
+                        null,
+                        activityDateTime
+                )
+        );
+
+        User savedUser = userRepository.findById(user.getUserId()).orElseThrow();
+        UserMonthlyStat savedStat = userMonthlyStatRepository.findByUser(savedUser).orElseThrow();
+        List<ValidScoreHistory> scoreHistories = validScoreHistoryRepository.findAll();
+
+        assertThat(correctResult.appliedScore()).isEqualTo(2);
+        assertThat(wrongResult.appliedScore()).isZero();
+        assertThat(wrongResult.scoreAfter()).isEqualTo(102);
+        assertThat(savedUser.getGActivityScore()).isEqualTo(102);
+        assertThat(savedStat.getMonthlyGScore()).isEqualTo(2);
+        assertThat(scoreHistories).hasSize(1);
+        assertThat(scoreHistories.get(0).getReason()).isEqualTo(ScoreReason.QUIZ);
     }
 
     private User createUser(String loginId, int eScore, int sScore, int gActivityScore, int gRepaymentScore) {


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #73 

## 📌 작업 내용
- ESG 활동 점수를 활동 유형별로 당일 1회만 부여하도록 제한
- 점수 중복 제한 시에도 활동 기록과 포인트 적립 흐름은 유지
- 퀴즈 정답/오답은 각각의 점수 정책을 유지하되, 당일 퀴즈 점수는 1회만 부여되도록 처리

## 🛠 변경 사항
- `ScoreService.applyActivityScore`에서 당일 동일 점수 사유의 `ValidScoreHistory` 존재 여부를 확인
- 이미 당일 점수 이력이 있으면 유저 점수, 월간 누적 점수, 점수 이력을 증가시키지 않고 `appliedScore = 0` 반환
- 제한 대상: `PHOTO`, `DONATION`, `PURCHASE`, `VOLUNTEER`, `QUIZ_CORRECT`, `QUIZ_WRONG`
- `LOAN_REPAY`는 일일 제한 대상에서 제외
- `RewardServiceTest`에 점수는 중복 제한되고 포인트는 계속 적립되는 케이스 추가
- `ScoreServiceTest`에 동일 활동 중복 제한 및 퀴즈 정답/오답 교차 제한 케이스 추가

## ✅ 테스트 결과
- [x] 로컬에서 정상 동작 확인
- [x] 빌드 에러 없음
