### PR TITLE
feat : 회원가입 시 ESG 점수 이력 초기화

### DIFF
--- a/src/main/java/com/shinhan/esg_be/domain/auth/service/AuthService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/auth/service/AuthService.java
@@ -7,6 +7,7 @@ import com.shinhan.esg_be.domain.auth.dto.request.AuthJoinRequest;
 import com.shinhan.esg_be.domain.auth.dto.request.AuthLoginRequest;
 import com.shinhan.esg_be.domain.auth.dto.response.IdentityVerificationResponse;
 import com.shinhan.esg_be.domain.auth.dto.response.TokenResponse;
+import com.shinhan.esg_be.domain.score.service.ScoreService;
 import com.shinhan.esg_be.domain.user.entity.User;
 import com.shinhan.esg_be.domain.user.repository.UserRepository;
 import com.shinhan.esg_be.global.exception.BadRequestException;
@@ -35,6 +36,7 @@ public class AuthService {
     private final StringRedisTemplate redisTemplate;
     private final PortOneIdentityVerificationService portOneIdentityVerificationService;
     private final ObjectMapper objectMapper;
+    private final ScoreService scoreService;
 
     @Value("${auth.verification-token-expiration}")
     private long verificationTokenValidityInMilliseconds;
@@ -77,7 +79,8 @@ public class AuthService {
                     verifiedIdentity.getCiDi()
             );
 
-            userRepository.save(user);
+            User savedUser = userRepository.save(user);
+            scoreService.initializeUserScore(savedUser.getUserId());
         }
 
         redisTemplate.delete(getVerifiedIdentityKey(req.getVerificationToken()));

--- a/src/test/java/com/shinhan/esg_be/domain/auth/service/AuthServiceTest.java
+++ b/src/test/java/com/shinhan/esg_be/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,91 @@
+package com.shinhan.esg_be.domain.auth.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.shinhan.esg_be.domain.auth.dto.internal.VerifiedIdentity;
+import com.shinhan.esg_be.domain.auth.dto.request.AuthJoinRequest;
+import com.shinhan.esg_be.domain.score.service.ScoreService;
+import com.shinhan.esg_be.domain.user.entity.User;
+import com.shinhan.esg_be.domain.user.repository.UserRepository;
+import com.shinhan.esg_be.global.security.JwtTokenProvider;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class AuthServiceTest {
+
+    @Test
+    @DisplayName("신규 회원가입 시 기본 점수 이력을 초기화한다")
+    void initializeScoreWhenJoinNewUser() throws Exception {
+        UserRepository userRepository = mock(UserRepository.class);
+        BCryptPasswordEncoder passwordEncoder = mock(BCryptPasswordEncoder.class);
+        JwtTokenProvider jwtTokenProvider = mock(JwtTokenProvider.class);
+        StringRedisTemplate redisTemplate = mock(StringRedisTemplate.class);
+        PortOneIdentityVerificationService portOneIdentityVerificationService = mock(PortOneIdentityVerificationService.class);
+        ScoreService scoreService = mock(ScoreService.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+        ValueOperations<String, String> valueOperations = mock(ValueOperations.class);
+
+        AuthService authService = new AuthService(
+                userRepository,
+                passwordEncoder,
+                jwtTokenProvider,
+                redisTemplate,
+                portOneIdentityVerificationService,
+                objectMapper,
+                scoreService
+        );
+
+        AuthJoinRequest request = createJoinRequest();
+        String verifiedIdentityJson = objectMapper.writeValueAsString(new VerifiedIdentity("ci-di-new-user"));
+
+        when(redisTemplate.opsForValue()).thenReturn(valueOperations);
+        when(valueOperations.get("VI:" + request.getVerificationToken())).thenReturn(verifiedIdentityJson);
+        when(userRepository.findByCiDi("ci-di-new-user")).thenReturn(Optional.empty());
+        when(passwordEncoder.encode(request.getPassword())).thenReturn("encoded-password");
+        when(userRepository.save(any(User.class))).thenAnswer(invocation -> {
+            User user = invocation.getArgument(0);
+            ReflectionTestUtils.setField(user, "userId", 100L);
+            return user;
+        });
+
+        authService.join(request);
+
+        verify(userRepository).save(any(User.class));
+        verify(scoreService).initializeUserScore(100L);
+        verify(redisTemplate).delete("VI:" + request.getVerificationToken());
+    }
+
+    private AuthJoinRequest createJoinRequest() {
+        AuthJoinRequest request = newInstance(AuthJoinRequest.class);
+        request.setLoginId("new-user");
+        request.setPassword("password");
+        request.setName("신규회원");
+        request.setEmail("new-user@test.com");
+        request.setPhoneNumber("010-1234-5678");
+        request.setBirthdate(LocalDate.of(2000, 1, 1));
+        request.setVerificationToken("verification-token");
+        return request;
+    }
+
+    private <T> T newInstance(Class<T> type) {
+        try {
+            var constructor = type.getDeclaredConstructor();
+            constructor.setAccessible(true);
+            return constructor.newInstance();
+        } catch (Exception exception) {
+            throw new IllegalStateException("Failed to instantiate " + type.getSimpleName(), exception);
+        }
+    }
+}


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #79

## 📌 작업 내용
- 신규 회원가입 시 ESG 초기 점수 이력을 생성하도록 처리
- 회원가입 흐름에서 월간 점수 통계가 함께 생성되도록 처리
- 신규 회원가입 시 점수 초기화 로직 호출 여부 테스트 추가

## 🛠 변경 사항
- `AuthService.join`에서 신규 사용자 저장 후 `ScoreService.initializeUserScore` 호출
- `ScoreService.initializeUserScore`를 통해 `valid_score_history`에 `INITIAL_SCORE` 이력 생성
- `ScoreService.initializeUserScore`를 통해 `user_monthly_stat` 생성
- `User.create`의 기본 점수 세팅은 유지하며, 점수는 중복 가산되지 않고 정책값으로 재초기화됨
- 탈퇴 계정 재활성화 흐름은 기존 정책 유지를 위해 변경하지 않음

## ✅ 테스트 결과
- [x] 로컬에서 정상 동작 확인
- [x] 빌드 에러 없음
