### PR TITLE
feat: 유효 점수 이력 기반 점수 산정 구조 개선

### DIFF
--- a/src/main/java/com/shinhan/esg_be/domain/activitystatus/dto/response/ActivityStatusLogItemResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/activitystatus/dto/response/ActivityStatusLogItemResponse.java
@@ -9,8 +9,6 @@ public record ActivityStatusLogItemResponse(
         String title,
         String category,
         ScoreReason reason,
-        Integer changeAmount,
-        Integer scoreAfter,
         LocalDateTime occurredAt
 ) {
 }

--- a/src/main/java/com/shinhan/esg_be/domain/activitystatus/service/MyActivityStatusService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/activitystatus/service/MyActivityStatusService.java
@@ -9,10 +9,11 @@ import com.shinhan.esg_be.domain.activitystatus.dto.response.ActivityStatusSumma
 import com.shinhan.esg_be.domain.policy.entity.EsgScorePolicy;
 import com.shinhan.esg_be.domain.policy.repository.EsgScorePolicyRepository;
 import com.shinhan.esg_be.domain.activitystatus.repository.ActivityStatusQueryRepository;
-import com.shinhan.esg_be.domain.score.entity.ExpiredScoreHistory;
 import com.shinhan.esg_be.domain.score.entity.ValidScoreHistory;
 import com.shinhan.esg_be.domain.stat.entity.UserMonthlyStat;
+import com.shinhan.esg_be.domain.stat.entity.UserScoreSnapshot;
 import com.shinhan.esg_be.domain.stat.repository.UserMonthlyStatRepository;
+import com.shinhan.esg_be.domain.stat.repository.UserScoreSnapshotRepository;
 import com.shinhan.esg_be.domain.user.entity.User;
 import com.shinhan.esg_be.domain.user.entity.enums.Grade;
 import com.shinhan.esg_be.domain.user.repository.UserRepository;
@@ -76,6 +77,7 @@ public class MyActivityStatusService {
     private final UserRepository userRepository;
     private final ActivityStatusQueryRepository activityStatusQueryRepository;
     private final UserMonthlyStatRepository userMonthlyStatRepository;
+    private final UserScoreSnapshotRepository userScoreSnapshotRepository;
     private final EsgScorePolicyRepository esgScorePolicyRepository;
     private final Clock clock;
 
@@ -182,46 +184,37 @@ public class MyActivityStatusService {
             months.add(currentMonth.minusMonths(index));
         }
 
-        LocalDateTime from = months.get(0).atDay(1).atStartOfDay();
-        LocalDateTime to = currentMonth.plusMonths(1).atDay(1).atStartOfDay();
-
-        List<ValidScoreHistory> histories = activityStatusQueryRepository.findHistoriesInPeriod(
-                user.getUserId(),
-                from,
-                to
-        );
-        List<ExpiredScoreHistory> expiredHistories = activityStatusQueryRepository.findExpiredHistoriesByValidUntilPeriod(
-                user.getUserId(),
-                from,
-                to
-        );
-
-        Map<YearMonth, Integer> monthlyNetDeltaByMonth = new HashMap<>();
-        for (ValidScoreHistory history : histories) {
-            YearMonth yearMonth = YearMonth.from(history.getCreatedAt());
-            monthlyNetDeltaByMonth.merge(yearMonth, history.getChangeAmount(), Integer::sum);
-        }
-        for (ExpiredScoreHistory history : expiredHistories) {
-            YearMonth yearMonth = YearMonth.from(history.getValidUntil());
-            monthlyNetDeltaByMonth.merge(yearMonth, -history.getChangeAmount(), Integer::sum);
-        }
-
-        Map<YearMonth, Integer> monthEndScoreByMonth = new HashMap<>();
-        int rollingScore = user.getTotalScore();
-        for (int index = months.size() - 1; index >= 0; index--) {
-            YearMonth yearMonth = months.get(index);
-            monthEndScoreByMonth.put(yearMonth, rollingScore);
-            rollingScore -= monthlyNetDeltaByMonth.getOrDefault(yearMonth, 0);
+        Map<YearMonth, UserScoreSnapshot> snapshotsByMonth = new HashMap<>();
+        for (UserScoreSnapshot snapshot : userScoreSnapshotRepository.findByUser_UserIdOrderBySnapshotDateDesc(user.getUserId())) {
+            YearMonth yearMonth = YearMonth.from(snapshot.getSnapshotDate());
+            snapshotsByMonth.put(yearMonth, snapshot);
         }
 
         return months.stream()
                 .map(yearMonth -> new MonthScoreSnapshot(
                         yearMonth.getYear(),
                         yearMonth.getMonthValue(),
-                        monthEndScoreByMonth.getOrDefault(yearMonth, user.getTotalScore()),
+                        resolveMonthScore(user, snapshotsByMonth, yearMonth, currentMonth),
                         yearMonth.equals(currentMonth)
                 ))
                 .toList();
+    }
+
+    private int resolveMonthScore(
+            User user,
+            Map<YearMonth, UserScoreSnapshot> snapshotsByMonth,
+            YearMonth yearMonth,
+            YearMonth currentMonth
+    ) {
+        if (yearMonth.equals(currentMonth)) {
+            return user.getTotalScore();
+        }
+
+        UserScoreSnapshot snapshot = snapshotsByMonth.get(yearMonth);
+        if (snapshot == null) {
+            return user.getTotalScore();
+        }
+        return snapshot.getTotalScore();
     }
 
     private ConsecutiveAchievementBadgeSummary buildConsecutiveAchievementBadgeSummary(User user) {
@@ -310,8 +303,6 @@ public class MyActivityStatusService {
                 resolveLogTitle(history.getReason()),
                 toResponseCategory(history.getCategory()),
                 history.getReason(),
-                history.getChangeAmount(),
-                history.getScoreAfter(),
                 history.getCreatedAt()
         );
     }

--- a/src/main/java/com/shinhan/esg_be/domain/score/entity/ExpiredScoreHistory.java
+++ b/src/main/java/com/shinhan/esg_be/domain/score/entity/ExpiredScoreHistory.java
@@ -50,10 +50,11 @@ public class ExpiredScoreHistory {
     @Column(nullable = false, length = 30)
     private ScoreReason reason;
 
-    @Column(name = "valid_until", nullable = false)
+    @Column(name = "valid_until")
     private LocalDateTime validUntil;
 
     @Column(name = "score_after", nullable = false)
+    @Deprecated
     private Integer scoreAfter;
 
     @CreatedDate

--- a/src/main/java/com/shinhan/esg_be/domain/score/entity/ValidScoreHistory.java
+++ b/src/main/java/com/shinhan/esg_be/domain/score/entity/ValidScoreHistory.java
@@ -50,10 +50,11 @@ public class ValidScoreHistory {
     @Column(nullable = false, length = 30)
     private ScoreReason reason;
 
-    @Column(name = "valid_until", nullable = false)
+    @Column(name = "valid_until")
     private LocalDateTime validUntil;
 
     @Column(name = "score_after", nullable = false)
+    @Deprecated
     private Integer scoreAfter;
 
     @CreatedDate

--- a/src/main/java/com/shinhan/esg_be/domain/score/repository/ValidScoreHistoryRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/score/repository/ValidScoreHistoryRepository.java
@@ -15,6 +15,8 @@ public interface ValidScoreHistoryRepository extends JpaRepository<ValidScoreHis
 
     List<ValidScoreHistory> findByUserAndValidUntilBefore(User user, LocalDateTime validUntil);
 
+    List<ValidScoreHistory> findByUser(User user);
+
     boolean existsByUserAndReason(User user, ScoreReason reason);
 
     boolean existsByUserAndReasonAndCreatedAtBetween(

--- a/src/main/java/com/shinhan/esg_be/domain/score/service/MonthlyScoreService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/score/service/MonthlyScoreService.java
@@ -6,7 +6,9 @@ import com.shinhan.esg_be.domain.score.entity.ValidScoreHistory;
 import com.shinhan.esg_be.domain.score.repository.ValidScoreHistoryRepository;
 import com.shinhan.esg_be.domain.score.service.result.MonthlyScoreSettlementResult;
 import com.shinhan.esg_be.domain.stat.entity.UserMonthlyStat;
+import com.shinhan.esg_be.domain.stat.entity.UserScoreSnapshot;
 import com.shinhan.esg_be.domain.stat.repository.UserMonthlyStatRepository;
+import com.shinhan.esg_be.domain.stat.repository.UserScoreSnapshotRepository;
 import com.shinhan.esg_be.domain.user.entity.User;
 import com.shinhan.esg_be.domain.user.repository.UserRepository;
 import com.shinhan.esg_be.global.common.enums.ScoreCategory;
@@ -15,6 +17,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 
@@ -33,6 +36,7 @@ public class MonthlyScoreService {
     private final UserMonthlyStatRepository userMonthlyStatRepository;
     private final EsgScorePolicyRepository esgScorePolicyRepository;
     private final ValidScoreHistoryRepository validScoreHistoryRepository;
+    private final UserScoreSnapshotRepository userScoreSnapshotRepository;
 
     @Transactional
     public MonthlyScoreSettlementResult settleMonthlyScore(Long userId, LocalDateTime settledAt) {
@@ -68,7 +72,7 @@ public class MonthlyScoreService {
             }
 
             user.applyScore(scoreCategory, bonusScore);
-            validScoreHistoryRepository.save(
+            validScoreHistoryRepository.saveAndFlush(
                     ValidScoreHistory.create(
                             user,
                             scoreCategory,
@@ -84,8 +88,19 @@ public class MonthlyScoreService {
         }
 
         // 월 마감이 끝나면 다음 달 집계를 위해 월 누적 점수를 초기화한다.
+        saveMonthlySnapshot(user, baseDateTime);
         userMonthlyStat.resetMonthlyScores();
         return new MonthlyScoreSettlementResult(bonusCount);
+    }
+
+    private void saveMonthlySnapshot(User user, LocalDateTime baseDateTime) {
+        LocalDate snapshotDate = baseDateTime.toLocalDate().withDayOfMonth(1).minusDays(1);
+        UserScoreSnapshot snapshot = userScoreSnapshotRepository
+                .findByUserAndSnapshotDate(user, snapshotDate)
+                .orElseGet(() -> UserScoreSnapshot.create(user, snapshotDate));
+
+        snapshot.updateScores(user);
+        userScoreSnapshotRepository.save(snapshot);
     }
 
     private int calculateNextConsecutiveCount(

--- a/src/main/java/com/shinhan/esg_be/domain/score/service/ScoreCalculatorService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/score/service/ScoreCalculatorService.java
@@ -14,6 +14,7 @@ public class ScoreCalculatorService {
         }
 
         int appliedScore = Math.max(0, command.scoreValue());
+        int monthlyAppliedScore = appliedScore;
         boolean isCapped = false;
 
         if (command.applyMonthlyCap() && appliedScore > 0) {
@@ -22,6 +23,7 @@ public class ScoreCalculatorService {
                 appliedScore = remainingMonthlyScore;
                 isCapped = true;
             }
+            monthlyAppliedScore = appliedScore;
         }
 
         int remainingTotalScore = Math.max(0, command.maxScore() - command.currentScore());
@@ -34,8 +36,9 @@ public class ScoreCalculatorService {
                 command.scoreCategory(),
                 appliedScore,
                 command.currentScore() + appliedScore,
-                command.monthlyCurrentScore() + appliedScore,
-                isCapped
+                command.monthlyCurrentScore() + monthlyAppliedScore,
+                isCapped,
+                monthlyAppliedScore
         );
     }
 }

--- a/src/main/java/com/shinhan/esg_be/domain/score/service/ScoreExpirationService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/score/service/ScoreExpirationService.java
@@ -16,7 +16,6 @@ import java.util.stream.Collectors;
 
 import static com.shinhan.esg_be.global.common.enums.ScoreReason.ABUSE;
 import static com.shinhan.esg_be.global.common.enums.ScoreReason.INITIAL_SCORE;
-import static com.shinhan.esg_be.global.common.enums.ScoreReason.NO_ACTIVITY;
 
 @Service
 @RequiredArgsConstructor
@@ -26,6 +25,7 @@ public class ScoreExpirationService {
     private final UserRepository userRepository;
     private final ValidScoreHistoryRepository validScoreHistoryRepository;
     private final ExpiredScoreHistoryRepository expiredScoreHistoryRepository;
+    private final ScoreRecalculationService scoreRecalculationService;
 
     @Transactional
     public int expireUserScores(Long userId, LocalDateTime expiredAt) {
@@ -37,16 +37,12 @@ public class ScoreExpirationService {
                 .stream()
                 .filter(validScoreHistory -> validScoreHistory.getReason() != INITIAL_SCORE)
                 .filter(validScoreHistory -> validScoreHistory.getReason() != ABUSE)
-                .filter(validScoreHistory -> validScoreHistory.getReason() != NO_ACTIVITY)
                 .collect(Collectors.toList());
         if (expiredScores.isEmpty()) {
             return 0;
         }
 
         for (ValidScoreHistory validScoreHistory : expiredScores) {
-            // 만료된 유효 점수만큼 사용자 점수를 차감하고 만료 이력으로 옮긴다.
-            user.applyScore(validScoreHistory.getCategory(), -validScoreHistory.getChangeAmount());
-
             expiredScoreHistoryRepository.save(
                     ExpiredScoreHistory.create(
                             user,
@@ -60,6 +56,8 @@ public class ScoreExpirationService {
         }
 
         validScoreHistoryRepository.deleteAll(expiredScores);
+        validScoreHistoryRepository.flush();
+        scoreRecalculationService.recalculateUserScore(user);
         return expiredScores.size();
     }
 }

--- a/src/main/java/com/shinhan/esg_be/domain/score/service/ScorePenaltyService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/score/service/ScorePenaltyService.java
@@ -49,7 +49,6 @@ public class ScorePenaltyService {
         applyPenaltyHistory(user, ScoreCategory.E, eReduction, ScoreReason.ABUSE, baseDateTime);
         applyPenaltyHistory(user, ScoreCategory.S, sReduction, ScoreReason.ABUSE, baseDateTime);
         applyPenaltyHistory(user, ScoreCategory.G_ACTIVITY, gReduction, ScoreReason.ABUSE, baseDateTime);
-
         user.increaseAbuseCount();
         if (Boolean.TRUE.equals(penaltyPolicy.getIsBlockLoan())) {
             user.blockLoan();
@@ -156,14 +155,15 @@ public class ScorePenaltyService {
             return;
         }
 
+        LocalDateTime validUntil = scoreReason == ScoreReason.ABUSE ? null : baseDateTime.plusYears(1);
         user.applyScore(scoreCategory, -reduction);
-        validScoreHistoryRepository.save(
+        validScoreHistoryRepository.saveAndFlush(
                 ValidScoreHistory.create(
                         user,
                         scoreCategory,
                         -reduction,
                         scoreReason,
-                        baseDateTime.plusYears(100),
+                        validUntil,
                         user.getScore(scoreCategory)
                 )
         );

--- a/src/main/java/com/shinhan/esg_be/domain/score/service/ScoreRecalculationService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/score/service/ScoreRecalculationService.java
@@ -1,0 +1,198 @@
+package com.shinhan.esg_be.domain.score.service;
+
+import com.shinhan.esg_be.domain.policy.entity.EsgScorePolicy;
+import com.shinhan.esg_be.domain.policy.repository.EsgScorePolicyRepository;
+import com.shinhan.esg_be.domain.score.entity.ValidScoreHistory;
+import com.shinhan.esg_be.domain.score.repository.ValidScoreHistoryRepository;
+import com.shinhan.esg_be.domain.user.entity.User;
+import com.shinhan.esg_be.domain.user.repository.UserRepository;
+import com.shinhan.esg_be.global.common.enums.ScoreCategory;
+import com.shinhan.esg_be.global.common.enums.ScoreReason;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.YearMonth;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class ScoreRecalculationService {
+
+    private final UserRepository userRepository;
+    private final ValidScoreHistoryRepository validScoreHistoryRepository;
+    private final EsgScorePolicyRepository esgScorePolicyRepository;
+
+    @Transactional
+    public void recalculateUserScore(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new IllegalArgumentException("User not found."));
+
+        recalculateUserScore(user);
+    }
+
+    @Transactional
+    public void recalculateUserScore(User user) {
+        List<ValidScoreHistory> histories = validScoreHistoryRepository.findByUser(user);
+        Map<ScoreCategory, EsgScorePolicy> policies = loadPolicies();
+
+        Map<ScoreCategory, Integer> scores = new EnumMap<>(ScoreCategory.class);
+        for (ScoreCategory category : ScoreCategory.values()) {
+            scores.put(category, resolveBaseScore(user, histories, policies.get(category), category));
+        }
+
+        Map<ScoreCategory, Integer> scoreFloors = applyAbuseHistories(histories, scores);
+        applyNoActivityHistories(histories, scores, scoreFloors);
+        applyMonthlyCappedActivityHistories(histories, scores, policies);
+        applyUncappedPositiveHistories(histories, scores);
+        applyCategoryMaximum(scores, policies);
+
+        user.replaceScores(
+                scores.get(ScoreCategory.E),
+                scores.get(ScoreCategory.S),
+                scores.get(ScoreCategory.G_ACTIVITY),
+                scores.get(ScoreCategory.G_REPAYMENT)
+        );
+    }
+
+    private Map<ScoreCategory, EsgScorePolicy> loadPolicies() {
+        Map<ScoreCategory, EsgScorePolicy> policies = new EnumMap<>(ScoreCategory.class);
+        for (ScoreCategory category : ScoreCategory.values()) {
+            esgScorePolicyRepository.findByCategoryAndIsActiveTrue(category)
+                    .ifPresent(policy -> policies.put(category, policy));
+        }
+        return policies;
+    }
+
+    private int resolveBaseScore(
+            User user,
+            List<ValidScoreHistory> histories,
+            EsgScorePolicy policy,
+            ScoreCategory category
+    ) {
+        int historyBaseScore = histories.stream()
+                .filter(history -> history.getReason() == ScoreReason.INITIAL_SCORE)
+                .filter(history -> history.getCategory() == category)
+                .mapToInt(ValidScoreHistory::getChangeAmount)
+                .sum();
+
+        if (historyBaseScore != 0) {
+            return historyBaseScore;
+        }
+        if (policy == null) {
+            return user.getScore(category);
+        }
+        return defaultIfNull(policy.getBaseScore());
+    }
+
+    private Map<ScoreCategory, Integer> applyAbuseHistories(
+            List<ValidScoreHistory> histories,
+            Map<ScoreCategory, Integer> scores
+    ) {
+        histories.stream()
+                .filter(history -> history.getReason() == ScoreReason.ABUSE)
+                .forEach(history -> scores.compute(
+                        history.getCategory(),
+                        (category, score) -> Math.max(0, defaultIfNull(score) + history.getChangeAmount())
+                ));
+
+        Map<ScoreCategory, Integer> scoreFloors = new EnumMap<>(ScoreCategory.class);
+        for (ScoreCategory category : ScoreCategory.values()) {
+            scoreFloors.put(category, defaultIfNull(scores.get(category)));
+        }
+        return scoreFloors;
+    }
+
+    private void applyNoActivityHistories(
+            List<ValidScoreHistory> histories,
+            Map<ScoreCategory, Integer> scores,
+            Map<ScoreCategory, Integer> scoreFloors
+    ) {
+        histories.stream()
+                .filter(history -> history.getReason() == ScoreReason.NO_ACTIVITY)
+                .forEach(history -> scores.compute(
+                        history.getCategory(),
+                        (category, score) -> Math.max(
+                                scoreFloors.getOrDefault(category, 0),
+                                defaultIfNull(score) + history.getChangeAmount()
+                        )
+                ));
+    }
+
+    private void applyMonthlyCappedActivityHistories(
+            List<ValidScoreHistory> histories,
+            Map<ScoreCategory, Integer> scores,
+            Map<ScoreCategory, EsgScorePolicy> policies
+    ) {
+        Map<ScoreCategory, Map<YearMonth, Integer>> monthlyScores = new EnumMap<>(ScoreCategory.class);
+
+        histories.stream()
+                .filter(this::isMonthlyCappedActivityReason)
+                .sorted(Comparator
+                        .comparing(ValidScoreHistory::getCreatedAt, Comparator.nullsLast(Comparator.naturalOrder()))
+                        .thenComparing(ValidScoreHistory::getScoreId))
+                .forEach(history -> {
+                    ScoreCategory category = history.getCategory();
+                    YearMonth yearMonth = resolveHistoryYearMonth(history);
+                    EsgScorePolicy policy = policies.get(category);
+                    int monthlyMaxScore = policy == null
+                            ? Integer.MAX_VALUE
+                            : defaultIfNull(policy.getMonthlyMaxScore());
+                    int monthlyCurrentScore = monthlyScores
+                            .computeIfAbsent(category, ignored -> new java.util.HashMap<>())
+                            .getOrDefault(yearMonth, 0);
+                    int remainingMonthlyScore = Math.max(0, monthlyMaxScore - monthlyCurrentScore);
+                    int appliedScore = Math.min(Math.max(0, history.getChangeAmount()), remainingMonthlyScore);
+
+                    monthlyScores.get(category).put(yearMonth, monthlyCurrentScore + appliedScore);
+                    scores.compute(category, (ignored, score) -> defaultIfNull(score) + appliedScore);
+                });
+    }
+
+    private void applyUncappedPositiveHistories(List<ValidScoreHistory> histories, Map<ScoreCategory, Integer> scores) {
+        histories.stream()
+                .filter(this::isUncappedPositiveReason)
+                .forEach(history -> scores.compute(
+                        history.getCategory(),
+                        (category, score) -> defaultIfNull(score) + Math.max(0, history.getChangeAmount())
+                ));
+    }
+
+    private void applyCategoryMaximum(
+            Map<ScoreCategory, Integer> scores,
+            Map<ScoreCategory, EsgScorePolicy> policies
+    ) {
+        for (ScoreCategory category : ScoreCategory.values()) {
+            EsgScorePolicy policy = policies.get(category);
+            int maxScore = policy == null ? Integer.MAX_VALUE : defaultIfNull(policy.getMaxScore());
+            scores.compute(category, (ignored, score) -> Math.min(maxScore, Math.max(0, defaultIfNull(score))));
+        }
+    }
+
+    private boolean isMonthlyCappedActivityReason(ValidScoreHistory history) {
+        return switch (history.getReason()) {
+            case DONATION, VOLUNTEER, PURCHASE, QUIZ, PHOTO -> true;
+            default -> false;
+        };
+    }
+
+    private boolean isUncappedPositiveReason(ValidScoreHistory history) {
+        return history.getReason() == ScoreReason.LOAN_REPAY
+                || history.getReason() == ScoreReason.CONSECUTIVE_BONUS;
+    }
+
+    private YearMonth resolveHistoryYearMonth(ValidScoreHistory history) {
+        if (history.getCreatedAt() == null) {
+            return YearMonth.now();
+        }
+        return YearMonth.from(history.getCreatedAt());
+    }
+
+    private int defaultIfNull(Integer value) {
+        return value == null ? 0 : value;
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/score/service/ScoreService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/score/service/ScoreService.java
@@ -55,8 +55,6 @@ public class ScoreService {
         userMonthlyStatRepository.findByUser(user)
                 .orElseGet(() -> userMonthlyStatRepository.save(UserMonthlyStat.create(user)));
 
-        LocalDateTime initializedAt = LocalDateTime.now();
-
         for (ScoreCategory scoreCategory : INITIAL_SCORE_CATEGORIES) {
             EsgScorePolicy esgScorePolicy = esgScorePolicyRepository.findByCategoryAndIsActiveTrue(scoreCategory)
                     .orElseThrow(() -> new IllegalArgumentException("ESG score policy not found."));
@@ -70,7 +68,7 @@ public class ScoreService {
                             scoreCategory,
                             baseScore,
                             ScoreReason.INITIAL_SCORE,
-                            initializedAt.plusYears(100),
+                            null,
                             user.getScore(scoreCategory)
                     )
             );
@@ -115,28 +113,31 @@ public class ScoreService {
                         isMonthlyCapTarget(scoreCategory)
                 )
         );
+        int earnedScore = defaultIfNull(activityRewardPolicy.getScoreValue());
+        int appliedScore = calculationResult.appliedScore();
 
-        if (calculationResult.appliedScore() > 0) {
-            user.applyScore(scoreCategory, calculationResult.appliedScore());
+        if (earnedScore > 0) {
             user.updateLastActivityDate(activityDateTime);
-            userMonthlyStat.addScore(scoreCategory, calculationResult.appliedScore());
+            userMonthlyStat.addScore(scoreCategory, calculationResult.monthlyAppliedScore());
+            user.applyScore(scoreCategory, appliedScore);
 
-            validScoreHistoryRepository.save(
+            validScoreHistoryRepository.saveAndFlush(
                     ValidScoreHistory.create(
                             user,
                             scoreCategory,
-                            calculationResult.appliedScore(),
+                            earnedScore,
                             scoreReason,
                             activityDateTime.plusYears(1),
-                            calculationResult.newScore()
+                            user.getScore(scoreCategory)
                     )
             );
         }
 
+        int scoreAfter = user.getScore(scoreCategory);
         return new ApplyActivityScoreResult(
                 scoreCategory,
-                calculationResult.appliedScore(),
-                calculationResult.newScore(),
+                appliedScore,
+                scoreAfter,
                 calculationResult.monthlyScoreAfter(),
                 calculationResult.cappedByMonthlyLimit()
         );

--- a/src/main/java/com/shinhan/esg_be/domain/score/service/result/ScoreCalculationResult.java
+++ b/src/main/java/com/shinhan/esg_be/domain/score/service/result/ScoreCalculationResult.java
@@ -7,6 +7,7 @@ public record ScoreCalculationResult(
         int appliedScore,
         int newScore,
         int monthlyScoreAfter,
-        boolean cappedByMonthlyLimit
+        boolean cappedByMonthlyLimit,
+        int monthlyAppliedScore
 ) {
 }

--- a/src/main/java/com/shinhan/esg_be/domain/stat/entity/UserScoreSnapshot.java
+++ b/src/main/java/com/shinhan/esg_be/domain/stat/entity/UserScoreSnapshot.java
@@ -1,0 +1,58 @@
+package com.shinhan.esg_be.domain.stat.entity;
+
+import com.shinhan.esg_be.domain.user.entity.User;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Entity
+@Table(
+        name = "user_score_snapshot",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_user_score_snapshot_user_date",
+                columnNames = {"user_id", "snapshot_date"}
+        )
+)
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserScoreSnapshot {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "snapshot_id")
+    private Long snapshotId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Column(name = "snapshot_date", nullable = false)
+    private LocalDate snapshotDate;
+
+    @Column(name = "total_score", nullable = false)
+    private Integer totalScore;
+
+    public static UserScoreSnapshot create(User user, LocalDate snapshotDate) {
+        UserScoreSnapshot snapshot = new UserScoreSnapshot();
+        snapshot.user = user;
+        snapshot.snapshotDate = snapshotDate;
+        snapshot.updateScores(user);
+        return snapshot;
+    }
+
+    public void updateScores(User user) {
+        this.totalScore = user.getTotalScore();
+    }
+}

--- a/src/main/java/com/shinhan/esg_be/domain/stat/repository/UserScoreSnapshotRepository.java
+++ b/src/main/java/com/shinhan/esg_be/domain/stat/repository/UserScoreSnapshotRepository.java
@@ -1,0 +1,16 @@
+package com.shinhan.esg_be.domain.stat.repository;
+
+import com.shinhan.esg_be.domain.stat.entity.UserScoreSnapshot;
+import com.shinhan.esg_be.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+public interface UserScoreSnapshotRepository extends JpaRepository<UserScoreSnapshot, Long> {
+
+    Optional<UserScoreSnapshot> findByUserAndSnapshotDate(User user, LocalDate snapshotDate);
+
+    List<UserScoreSnapshot> findByUser_UserIdOrderBySnapshotDateDesc(Long userId);
+}

--- a/src/main/java/com/shinhan/esg_be/domain/user/entity/User.java
+++ b/src/main/java/com/shinhan/esg_be/domain/user/entity/User.java
@@ -160,6 +160,14 @@ public class User extends BaseTimeEntity {
         recalculateGrade();
     }
 
+    public void replaceScores(int eScore, int sScore, int gActivityScore, int gRepaymentScore) {
+        this.eScore = eScore;
+        this.sScore = sScore;
+        this.gActivityScore = gActivityScore;
+        this.gRepaymentScore = gRepaymentScore;
+        recalculateGrade();
+    }
+
     public void applyPoint(int pointDelta) {
         if (pointDelta == 0) {
             return;

--- a/src/test/java/com/shinhan/esg_be/domain/point/service/PointServiceTest.java
+++ b/src/test/java/com/shinhan/esg_be/domain/point/service/PointServiceTest.java
@@ -72,6 +72,7 @@ class PointServiceTest {
 
     @BeforeEach
     void setUp() {
+        userPointRepository.deleteAllInBatch();
         activityRewardPolicyRepository.deleteAllInBatch();
         pointPolicyRepository.deleteAllInBatch();
     }

--- a/src/test/java/com/shinhan/esg_be/domain/score/service/MonthlyScoreServiceTest.java
+++ b/src/test/java/com/shinhan/esg_be/domain/score/service/MonthlyScoreServiceTest.java
@@ -7,6 +7,7 @@ import com.shinhan.esg_be.domain.score.repository.ValidScoreHistoryRepository;
 import com.shinhan.esg_be.domain.score.service.result.MonthlyScoreSettlementResult;
 import com.shinhan.esg_be.domain.stat.entity.UserMonthlyStat;
 import com.shinhan.esg_be.domain.stat.repository.UserMonthlyStatRepository;
+import com.shinhan.esg_be.domain.stat.repository.UserScoreSnapshotRepository;
 import com.shinhan.esg_be.domain.user.entity.User;
 import com.shinhan.esg_be.domain.user.entity.enums.Grade;
 import com.shinhan.esg_be.domain.user.entity.enums.UserType;
@@ -47,8 +48,13 @@ class MonthlyScoreServiceTest {
     @Autowired
     private ValidScoreHistoryRepository validScoreHistoryRepository;
 
+    @Autowired
+    private UserScoreSnapshotRepository userScoreSnapshotRepository;
+
     @BeforeEach
     void setUp() {
+        validScoreHistoryRepository.deleteAllInBatch();
+        userScoreSnapshotRepository.deleteAllInBatch();
         esgScorePolicyRepository.deleteAllInBatch();
     }
 
@@ -60,6 +66,8 @@ class MonthlyScoreServiceTest {
         esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.E, 100, 5, 3, 10, 50));
         esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.S, 500, 25, 3, 50, 250));
         esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.G_ACTIVITY, 200, 10, 3, 10, 100));
+        esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.G_REPAYMENT, 200, 0, 0, 0, 100));
+        seedInitialScores(user);
 
         MonthlyScoreSettlementResult result = monthlyScoreService.settleMonthlyScore(
                 user.getUserId(),
@@ -79,8 +87,7 @@ class MonthlyScoreServiceTest {
         assertThat(savedStat.getMonthlyEScore()).isZero();
         assertThat(savedStat.getMonthlySScore()).isZero();
         assertThat(savedStat.getMonthlyGScore()).isZero();
-        assertThat(scoreHistories).hasSize(2);
-        assertThat(scoreHistories).allMatch(history -> history.getReason() == ScoreReason.CONSECUTIVE_BONUS);
+        assertThat(scoreHistories.stream().filter(history -> history.getReason() == ScoreReason.CONSECUTIVE_BONUS)).hasSize(2);
     }
 
     @Test
@@ -91,6 +98,8 @@ class MonthlyScoreServiceTest {
         esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.E, 100, 5, 3, 10, 50));
         esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.S, 500, 25, 3, 50, 250));
         esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.G_ACTIVITY, 200, 10, 3, 20, 100));
+        esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.G_REPAYMENT, 200, 0, 0, 0, 100));
+        seedInitialScores(user);
 
         MonthlyScoreSettlementResult result = monthlyScoreService.settleMonthlyScore(
                 user.getUserId(),
@@ -110,7 +119,16 @@ class MonthlyScoreServiceTest {
         assertThat(savedStat.getMonthlyEScore()).isZero();
         assertThat(savedStat.getMonthlySScore()).isZero();
         assertThat(savedStat.getMonthlyGScore()).isZero();
-        assertThat(validScoreHistoryRepository.findAll()).isEmpty();
+        assertThat(validScoreHistoryRepository.findAll()).allMatch(history -> history.getReason() == ScoreReason.INITIAL_SCORE);
+    }
+
+    private void seedInitialScores(User user) {
+        validScoreHistoryRepository.saveAll(List.of(
+                ValidScoreHistory.create(user, ScoreCategory.E, 50, ScoreReason.INITIAL_SCORE, null, 50),
+                ValidScoreHistory.create(user, ScoreCategory.S, 250, ScoreReason.INITIAL_SCORE, null, 250),
+                ValidScoreHistory.create(user, ScoreCategory.G_ACTIVITY, 100, ScoreReason.INITIAL_SCORE, null, 100),
+                ValidScoreHistory.create(user, ScoreCategory.G_REPAYMENT, 100, ScoreReason.INITIAL_SCORE, null, 100)
+        ));
     }
 
     private User createUser(String loginId, int eScore, int sScore, int gActivityScore, int gRepaymentScore) {

--- a/src/test/java/com/shinhan/esg_be/domain/score/service/ScoreExpirationServiceTest.java
+++ b/src/test/java/com/shinhan/esg_be/domain/score/service/ScoreExpirationServiceTest.java
@@ -4,6 +4,8 @@ import com.shinhan.esg_be.domain.score.entity.ExpiredScoreHistory;
 import com.shinhan.esg_be.domain.score.entity.ValidScoreHistory;
 import com.shinhan.esg_be.domain.score.repository.ExpiredScoreHistoryRepository;
 import com.shinhan.esg_be.domain.score.repository.ValidScoreHistoryRepository;
+import com.shinhan.esg_be.domain.policy.entity.EsgScorePolicy;
+import com.shinhan.esg_be.domain.policy.repository.EsgScorePolicyRepository;
 import com.shinhan.esg_be.domain.user.entity.User;
 import com.shinhan.esg_be.domain.user.entity.enums.Grade;
 import com.shinhan.esg_be.domain.user.entity.enums.UserType;
@@ -11,6 +13,7 @@ import com.shinhan.esg_be.domain.user.repository.UserRepository;
 import com.shinhan.esg_be.global.common.enums.ScoreCategory;
 import com.shinhan.esg_be.global.common.enums.ScoreReason;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -40,10 +43,41 @@ class ScoreExpirationServiceTest {
     @Autowired
     private ExpiredScoreHistoryRepository expiredScoreHistoryRepository;
 
+    @Autowired
+    private EsgScorePolicyRepository esgScorePolicyRepository;
+
+    @BeforeEach
+    void setUp() {
+        validScoreHistoryRepository.deleteAllInBatch();
+        expiredScoreHistoryRepository.deleteAllInBatch();
+        esgScorePolicyRepository.deleteAllInBatch();
+    }
+
     @Test
-    @DisplayName("만료된 점수는 사용자 점수에서 차감하고 만료 이력으로 이동한다")
+    @DisplayName("만료된 점수는 만료 이력으로 이동하고 남은 유효 이력으로 점수를 재계산한다")
     void expireUserScores() {
         User user = userRepository.save(createUser("expire-user-1", 70, 250, 100, 100));
+        esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.E, 100, 25, 3, 10, 50));
+        validScoreHistoryRepository.save(
+                ValidScoreHistory.create(
+                        user,
+                        ScoreCategory.E,
+                        50,
+                        ScoreReason.INITIAL_SCORE,
+                        null,
+                        50
+                )
+        );
+        validScoreHistoryRepository.save(
+                ValidScoreHistory.create(
+                        user,
+                        ScoreCategory.E,
+                        10,
+                        ScoreReason.PHOTO,
+                        LocalDateTime.of(2026, 5, 1, 0, 0),
+                        60
+                )
+        );
         validScoreHistoryRepository.save(
                 ValidScoreHistory.create(
                         user,
@@ -66,21 +100,31 @@ class ScoreExpirationServiceTest {
 
         assertThat(expiredCount).isEqualTo(1);
         assertThat(savedUser.getEScore()).isEqualTo(60);
-        assertThat(validScoreHistories).isEmpty();
+        assertThat(validScoreHistories).hasSize(2);
         assertThat(expiredScoreHistories).hasSize(1);
         assertThat(expiredScoreHistories.get(0).getReason()).isEqualTo(ScoreReason.PHOTO);
-        assertThat(expiredScoreHistories.get(0).getScoreAfter()).isEqualTo(60);
     }
 
     @Test
     @DisplayName("만료 대상 점수가 없으면 아무 것도 처리하지 않는다")
     void expireUserScoresWithoutExpiredTarget() {
         User user = userRepository.save(createUser("expire-user-2", 70, 250, 100, 100));
+        esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.E, 100, 25, 3, 10, 50));
         validScoreHistoryRepository.save(
                 ValidScoreHistory.create(
                         user,
                         ScoreCategory.E,
-                        10,
+                        50,
+                        ScoreReason.INITIAL_SCORE,
+                        null,
+                        50
+                )
+        );
+        validScoreHistoryRepository.save(
+                ValidScoreHistory.create(
+                        user,
+                        ScoreCategory.E,
+                        20,
                         ScoreReason.PHOTO,
                         LocalDateTime.of(2026, 5, 1, 0, 0),
                         70
@@ -98,7 +142,7 @@ class ScoreExpirationServiceTest {
 
         assertThat(expiredCount).isZero();
         assertThat(savedUser.getEScore()).isEqualTo(70);
-        assertThat(validScoreHistories).hasSize(1);
+        assertThat(validScoreHistories).hasSize(2);
         assertThat(expiredScoreHistories).isEmpty();
     }
 
@@ -106,13 +150,14 @@ class ScoreExpirationServiceTest {
     @DisplayName("초기 점수와 어뷰징 감점은 만료 대상에서 제외한다")
     void excludeInitialScoreAndAbuseFromExpiration() {
         User user = userRepository.save(createUser("expire-user-3", 45, 250, 100, 100));
+        esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.E, 100, 25, 3, 10, 50));
         validScoreHistoryRepository.save(
                 ValidScoreHistory.create(
                         user,
                         ScoreCategory.E,
-                        5,
+                        -5,
                         ScoreReason.ABUSE,
-                        LocalDateTime.of(2026, 4, 1, 0, 0),
+                        null,
                         45
                 )
         );
@@ -122,7 +167,7 @@ class ScoreExpirationServiceTest {
                         ScoreCategory.E,
                         50,
                         ScoreReason.INITIAL_SCORE,
-                        LocalDateTime.of(2026, 4, 1, 0, 0),
+                        null,
                         50
                 )
         );
@@ -162,6 +207,25 @@ class ScoreExpirationServiceTest {
         ReflectionTestUtils.setField(user, "isActive", true);
         ReflectionTestUtils.setField(user, "isLinked", false);
         return user;
+    }
+
+    private EsgScorePolicy createEsgScorePolicy(
+            ScoreCategory scoreCategory,
+            int maxScore,
+            int monthlyMaxScore,
+            int consecutiveTargetMonths,
+            int consecutiveBonusScore,
+            int baseScore
+    ) {
+        EsgScorePolicy esgScorePolicy = newInstance(EsgScorePolicy.class);
+        ReflectionTestUtils.setField(esgScorePolicy, "category", scoreCategory);
+        ReflectionTestUtils.setField(esgScorePolicy, "monthlyMaxScore", monthlyMaxScore);
+        ReflectionTestUtils.setField(esgScorePolicy, "maxScore", maxScore);
+        ReflectionTestUtils.setField(esgScorePolicy, "consecutiveTargetMonths", consecutiveTargetMonths);
+        ReflectionTestUtils.setField(esgScorePolicy, "consecutiveBonusScore", consecutiveBonusScore);
+        ReflectionTestUtils.setField(esgScorePolicy, "isActive", true);
+        ReflectionTestUtils.setField(esgScorePolicy, "baseScore", baseScore);
+        return esgScorePolicy;
     }
 
     private <T> T newInstance(Class<T> type) {

--- a/src/test/java/com/shinhan/esg_be/domain/score/service/ScorePenaltyServiceTest.java
+++ b/src/test/java/com/shinhan/esg_be/domain/score/service/ScorePenaltyServiceTest.java
@@ -2,6 +2,8 @@ package com.shinhan.esg_be.domain.score.service;
 
 import com.shinhan.esg_be.domain.policy.entity.PenaltyPolicy;
 import com.shinhan.esg_be.domain.policy.entity.enums.PenaltyType;
+import com.shinhan.esg_be.domain.policy.entity.EsgScorePolicy;
+import com.shinhan.esg_be.domain.policy.repository.EsgScorePolicyRepository;
 import com.shinhan.esg_be.domain.policy.repository.PenaltyPolicyRepository;
 import com.shinhan.esg_be.domain.score.entity.ValidScoreHistory;
 import com.shinhan.esg_be.domain.score.repository.ValidScoreHistoryRepository;
@@ -43,9 +45,14 @@ class ScorePenaltyServiceTest {
     @Autowired
     private ValidScoreHistoryRepository validScoreHistoryRepository;
 
+    @Autowired
+    private EsgScorePolicyRepository esgScorePolicyRepository;
+
     @BeforeEach
     void setUp() {
+        validScoreHistoryRepository.deleteAllInBatch();
         penaltyPolicyRepository.deleteAllInBatch();
+        esgScorePolicyRepository.deleteAllInBatch();
     }
 
     @Test
@@ -53,6 +60,8 @@ class ScorePenaltyServiceTest {
     void applyAbusePenalty() {
         User user = userRepository.save(createUser("penalty-user-1", 50, 250, 100, 100));
         penaltyPolicyRepository.save(createPenaltyPolicy(PenaltyType.ABUSE, 5, 25, 10, true));
+        seedPolicies();
+        seedInitialScores(user);
 
         PenaltyApplicationResult result = scorePenaltyService.applyAbusePenalty(
                 user.getUserId(),
@@ -74,8 +83,12 @@ class ScorePenaltyServiceTest {
         assertThat(savedUser.getGRepaymentScore()).isEqualTo(100);
         assertThat(savedUser.getAbuseCount()).isEqualTo(1);
         assertThat(savedUser.getIsLoanBlocked()).isTrue();
-        assertThat(histories).hasSize(3);
-        assertThat(histories).allMatch(history -> history.getReason() == ScoreReason.ABUSE);
+        assertThat(histories.stream().filter(history -> history.getReason() == ScoreReason.INITIAL_SCORE).count())
+                .isEqualTo(4);
+        assertThat(histories.stream().filter(history -> history.getReason() == ScoreReason.ABUSE).count())
+                .isEqualTo(3);
+        assertThat(histories.stream().filter(history -> history.getReason() == ScoreReason.ABUSE))
+                .allMatch(history -> history.getValidUntil() == null);
     }
 
     @Test
@@ -83,6 +96,7 @@ class ScorePenaltyServiceTest {
     void applyNoActivityPenaltyWithoutDroppingBelowFloor() {
         User user = userRepository.save(createUser("penalty-user-2", 46, 235, 91, 100));
         penaltyPolicyRepository.save(createPenaltyPolicy(PenaltyType.NO_ACTIVITY, 2, 10, 4, false));
+        seedPolicies();
         seedScoreFloor(user);
         ReflectionTestUtils.setField(user, "lastActivityDate", LocalDateTime.of(2026, 2, 1, 0, 0));
 
@@ -108,14 +122,30 @@ class ScorePenaltyServiceTest {
 
     private void seedScoreFloor(User user) {
         validScoreHistoryRepository.saveAll(List.of(
-                ValidScoreHistory.create(user, ScoreCategory.E, 50, ScoreReason.INITIAL_SCORE, LocalDateTime.of(2126, 1, 1, 0, 0), 50),
-                ValidScoreHistory.create(user, ScoreCategory.S, 250, ScoreReason.INITIAL_SCORE, LocalDateTime.of(2126, 1, 1, 0, 0), 250),
-                ValidScoreHistory.create(user, ScoreCategory.G_ACTIVITY, 100, ScoreReason.INITIAL_SCORE, LocalDateTime.of(2126, 1, 1, 0, 0), 100),
-                ValidScoreHistory.create(user, ScoreCategory.G_REPAYMENT, 100, ScoreReason.INITIAL_SCORE, LocalDateTime.of(2126, 1, 1, 0, 0), 100),
-                ValidScoreHistory.create(user, ScoreCategory.E, -5, ScoreReason.ABUSE, LocalDateTime.of(2126, 1, 1, 0, 0), 45),
-                ValidScoreHistory.create(user, ScoreCategory.S, -25, ScoreReason.ABUSE, LocalDateTime.of(2126, 1, 1, 0, 0), 225),
-                ValidScoreHistory.create(user, ScoreCategory.G_ACTIVITY, -10, ScoreReason.ABUSE, LocalDateTime.of(2126, 1, 1, 0, 0), 90)
+                ValidScoreHistory.create(user, ScoreCategory.E, 50, ScoreReason.INITIAL_SCORE, null, 50),
+                ValidScoreHistory.create(user, ScoreCategory.S, 250, ScoreReason.INITIAL_SCORE, null, 250),
+                ValidScoreHistory.create(user, ScoreCategory.G_ACTIVITY, 100, ScoreReason.INITIAL_SCORE, null, 100),
+                ValidScoreHistory.create(user, ScoreCategory.G_REPAYMENT, 100, ScoreReason.INITIAL_SCORE, null, 100),
+                ValidScoreHistory.create(user, ScoreCategory.E, -5, ScoreReason.ABUSE, null, 45),
+                ValidScoreHistory.create(user, ScoreCategory.S, -25, ScoreReason.ABUSE, null, 225),
+                ValidScoreHistory.create(user, ScoreCategory.G_ACTIVITY, -10, ScoreReason.ABUSE, null, 90)
         ));
+    }
+
+    private void seedInitialScores(User user) {
+        validScoreHistoryRepository.saveAll(List.of(
+                ValidScoreHistory.create(user, ScoreCategory.E, 50, ScoreReason.INITIAL_SCORE, null, 50),
+                ValidScoreHistory.create(user, ScoreCategory.S, 250, ScoreReason.INITIAL_SCORE, null, 250),
+                ValidScoreHistory.create(user, ScoreCategory.G_ACTIVITY, 100, ScoreReason.INITIAL_SCORE, null, 100),
+                ValidScoreHistory.create(user, ScoreCategory.G_REPAYMENT, 100, ScoreReason.INITIAL_SCORE, null, 100)
+        ));
+    }
+
+    private void seedPolicies() {
+        esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.E, 100, 5, 3, 10, 50));
+        esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.S, 500, 25, 3, 50, 250));
+        esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.G_ACTIVITY, 200, 10, 3, 20, 100));
+        esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.G_REPAYMENT, 200, 0, 0, 0, 100));
     }
 
     private PenaltyPolicy createPenaltyPolicy(
@@ -133,6 +163,25 @@ class ScorePenaltyServiceTest {
         ReflectionTestUtils.setField(penaltyPolicy, "isBaseReduction", penaltyType == PenaltyType.ABUSE);
         ReflectionTestUtils.setField(penaltyPolicy, "isBlockLoan", blockLoan);
         return penaltyPolicy;
+    }
+
+    private EsgScorePolicy createEsgScorePolicy(
+            ScoreCategory scoreCategory,
+            int maxScore,
+            int monthlyMaxScore,
+            int consecutiveTargetMonths,
+            int consecutiveBonusScore,
+            int baseScore
+    ) {
+        EsgScorePolicy esgScorePolicy = newInstance(EsgScorePolicy.class);
+        ReflectionTestUtils.setField(esgScorePolicy, "category", scoreCategory);
+        ReflectionTestUtils.setField(esgScorePolicy, "monthlyMaxScore", monthlyMaxScore);
+        ReflectionTestUtils.setField(esgScorePolicy, "maxScore", maxScore);
+        ReflectionTestUtils.setField(esgScorePolicy, "consecutiveTargetMonths", consecutiveTargetMonths);
+        ReflectionTestUtils.setField(esgScorePolicy, "consecutiveBonusScore", consecutiveBonusScore);
+        ReflectionTestUtils.setField(esgScorePolicy, "isActive", true);
+        ReflectionTestUtils.setField(esgScorePolicy, "baseScore", baseScore);
+        return esgScorePolicy;
     }
 
     private User createUser(String loginId, int eScore, int sScore, int gActivityScore, int gRepaymentScore) {

--- a/src/test/java/com/shinhan/esg_be/domain/score/service/ScoreServiceTest.java
+++ b/src/test/java/com/shinhan/esg_be/domain/score/service/ScoreServiceTest.java
@@ -17,6 +17,7 @@ import com.shinhan.esg_be.domain.user.repository.UserRepository;
 import com.shinhan.esg_be.global.common.enums.ActivityType;
 import com.shinhan.esg_be.global.common.enums.ScoreCategory;
 import com.shinhan.esg_be.global.common.enums.ScoreReason;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -55,6 +56,9 @@ class ScoreServiceTest {
 
     @Autowired
     private ValidScoreHistoryRepository validScoreHistoryRepository;
+
+    @Autowired
+    private EntityManager entityManager;
 
     @BeforeEach
     void setUp() {
@@ -95,10 +99,20 @@ class ScoreServiceTest {
     @Test
     @DisplayName("월 최대 점수를 넘기면 남은 점수만 반영한다")
     void applyRemainingScoreWithinMonthlyLimit() {
-        User user = userRepository.save(createUser("score-user-2", 50, 250, 100, 100));
+        User user = userRepository.save(createUser("score-user-2", 54, 250, 100, 100));
         userMonthlyStatRepository.save(createUserMonthlyStat(user, 4, 0, 0));
         activityRewardPolicyRepository.save(createActivityRewardPolicy(ActivityType.PHOTO, ScoreCategory.E, 3));
         esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.E, 100, 5, 3, 10, 50));
+        for (int day = 1; day <= 4; day++) {
+            saveScoreHistory(
+                    user,
+                    ScoreCategory.E,
+                    1,
+                    ScoreReason.PHOTO,
+                    LocalDateTime.of(2027, 4, day, 0, 0),
+                    LocalDateTime.of(2026, 4, day, 10, 0)
+            );
+        }
 
         ApplyActivityScoreResult result = scoreService.applyActivityScore(
                 new ApplyActivityScoreCommand(
@@ -114,7 +128,7 @@ class ScoreServiceTest {
 
         assertThat(result.appliedScore()).isEqualTo(1);
         assertThat(result.cappedByMonthlyLimit()).isTrue();
-        assertThat(savedUser.getEScore()).isEqualTo(51);
+        assertThat(savedUser.getEScore()).isEqualTo(55);
         assertThat(savedStat.getMonthlyEScore()).isEqualTo(5);
     }
 
@@ -124,7 +138,7 @@ class ScoreServiceTest {
         User user = userRepository.save(createUser("score-user-3", 95, 250, 100, 100));
         userMonthlyStatRepository.save(createUserMonthlyStat(user, 0, 0, 0));
         activityRewardPolicyRepository.save(createActivityRewardPolicy(ActivityType.PHOTO, ScoreCategory.E, 10));
-        esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.E, 100, 5, 3, 10, 50));
+        esgScorePolicyRepository.save(createEsgScorePolicy(ScoreCategory.E, 100, 5, 3, 10, 95));
 
         ApplyActivityScoreResult result = scoreService.applyActivityScore(
                 new ApplyActivityScoreCommand(
@@ -172,6 +186,7 @@ class ScoreServiceTest {
         assertThat(savedStat.getMonthlyGScore()).isZero();
         assertThat(scoreHistories).hasSize(4);
         assertThat(scoreHistories).allMatch(history -> history.getReason() == ScoreReason.INITIAL_SCORE);
+        assertThat(scoreHistories).allMatch(history -> history.getValidUntil() == null);
         assertThat(scoreHistories).extracting(ValidScoreHistory::getChangeAmount)
                 .containsExactly(50, 250, 100, 100);
     }
@@ -312,6 +327,26 @@ class ScoreServiceTest {
         ReflectionTestUtils.setField(esgScorePolicy, "isActive", true);
         ReflectionTestUtils.setField(esgScorePolicy, "baseScore", baseScore);
         return esgScorePolicy;
+    }
+
+    private void saveScoreHistory(
+            User user,
+            ScoreCategory scoreCategory,
+            int changeAmount,
+            ScoreReason scoreReason,
+            LocalDateTime validUntil,
+            LocalDateTime createdAt
+    ) {
+        ValidScoreHistory savedHistory = validScoreHistoryRepository.saveAndFlush(
+                ValidScoreHistory.create(user, scoreCategory, changeAmount, scoreReason, validUntil, user.getScore(scoreCategory))
+        );
+
+        entityManager.createNativeQuery("update valid_score_history set created_at = :createdAt where score_id = :scoreId")
+                .setParameter("createdAt", createdAt)
+                .setParameter("scoreId", savedHistory.getScoreId())
+                .executeUpdate();
+        entityManager.flush();
+        entityManager.clear();
     }
 
     private <T> T newInstance(Class<T> type) {


### PR DESCRIPTION
## 🔗 관련 이슈
<!-- 이슈 번호를 적어주세요. 머지 시 자동으로 이슈가 닫힙니다. -->
Closes #84

## 📌 작업 내용
<!-- 어떤 작업을 했는지 간단히 설명 -->
- 점수 이력 만료 정책을 유효 이력 기반 재계산 방식으로 개선했습니다.
- 월별 점수 그래프/등급 이력용 점수 스냅샷 구조를 추가했습니다.
- 최근 점수 획득 내역을 최근 ESG 활동 내역으로 변경했습니다.

## 🛠 변경 사항
<!-- 주요 변경 파일이나 로직을 설명 -->
- `valid_score_history`의 `change_amount` 의미를 실제 반영 점수가 아닌 정책상 획득 점수로 변경했습니다.
- 활동 점수는 기존처럼 즉시 누적하되, 만료 배치에서는 남은 유효 이력 기준으로 점수를 재계산하도록 변경했습니다.
- `INITIAL_SCORE`, `ABUSE`는 만료되지 않도록 `valid_until = null`로 처리했습니다.
- `NO_ACTIVITY`, 일반 활동 점수, `CONSECUTIVE_BONUS`는 1년 유효 이력으로 처리했습니다.
- 만료 대상 이력은 `expired_score_history`로 이동하고, 사용자 점수는 단순 차감이 아닌 재계산 결과로 갱신합니다.
- 월별 점수 기록용 `user_score_snapshot` 엔티티와 Repository를 추가했습니다.
- 월 마감 시 사용자 총점을 스냅샷으로 저장하고, 활동 현황 overview의 월별 그래프/등급 이력에서 사용하도록 변경했습니다.
- 최근 ESG 활동 내역 응답에서 `changeAmount`, `scoreAfter`를 제거하고 활동명/카테고리/발생일 중심으로 응답하도록 변경했습니다.
- 점수 정책 변경에 맞춰 관련 테스트를 수정했습니다.

## ✅ 테스트 결과
<!-- 테스트를 어떻게 했는지 (로컬 실행, API 테스트 등) -->
- [x] 로컬에서 정상 동작 확인
- [ ] API 테스트 완료 (해당되면)
- [x] 빌드 에러 없음