### PR TITLE
feat: 금융상품 가입 불가 사유 응답 추가

### DIFF
--- a/src/main/java/com/shinhan/esg_be/domain/bank/dto/response/FinanceProductResponse.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/dto/response/FinanceProductResponse.java
@@ -12,6 +12,7 @@ public record FinanceProductResponse(
         BigDecimal appliedRate,
         Long loanLimit,
         boolean available,
+        String unavailableReason,
         Integer durationMonths,
         Long monthlyPaymentAmount,
         String description

--- a/src/main/java/com/shinhan/esg_be/domain/bank/service/FinanceService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/service/FinanceService.java
@@ -53,6 +53,15 @@ public class FinanceService {
     private static final BigDecimal LOAN_RATE_700 = new BigDecimal("8.50");
     private static final BigDecimal LOAN_RATE_800 = new BigDecimal("7.00");
     private static final BigDecimal LOAN_RATE_900 = new BigDecimal("6.00");
+    private static final String ESG_MASTER_KEYWORD = "ESG 마스터";
+    private static final int ESG_MASTER_MIN_TOTAL_SCORE = 900;
+
+    private static final String REASON_AVAILABLE = "AVAILABLE";
+    private static final String REASON_ALREADY_JOINED = "ALREADY_JOINED";
+    private static final String REASON_LOW_SCORE_FOR_ESG_MASTER = "LOW_SCORE_FOR_ESG_MASTER";
+    private static final String REASON_HAS_ACTIVE_LOAN = "HAS_ACTIVE_LOAN";
+    private static final String REASON_LOAN_BLOCKED = "LOAN_BLOCKED";
+    private static final String REASON_LOW_SCORE = "LOW_SCORE";
 
     private final FinancialProductRepository financialProductRepository;
     private final LoanHistoryRepository loanHistoryRepository;
@@ -122,8 +131,7 @@ public class FinanceService {
         Set<Long> activeSavingProductIds = getActiveSavingProductIds(user, productType);
         var products = financialProductRepository.findByTypeAndIsActiveTrue(productType)
                 .stream()
-                .filter(product -> productType == ProductType.LOAN || !activeSavingProductIds.contains(product.getFinProductId()))
-                .map(product -> toResponse(user, product, productType))
+                .map(product -> toResponse(user, product, productType, activeSavingProductIds))
                 .toList();
 
         return new FinanceProductListResponse(products);
@@ -140,11 +148,17 @@ public class FinanceService {
                 .collect(Collectors.toSet());
     }
 
-    private FinanceProductResponse toResponse(User user, FinancialProduct product, ProductType productType) {
+    private FinanceProductResponse toResponse(
+            User user,
+            FinancialProduct product,
+            ProductType productType,
+            Set<Long> activeSavingProductIds
+    ) {
         if (productType == ProductType.LOAN) {
             LoanOffer loanOffer = calculateLoanOffer(user);
             boolean hasActiveLoan = !userLoanRepository.findByUserAndStatus(user, LoanStatus.ACTIVE).isEmpty();
             boolean available = loanOffer.available() && !hasActiveLoan && !user.getIsLoanBlocked();
+            String unavailableReason = determineLoanUnavailableReason(loanOffer.available(), hasActiveLoan, user.getIsLoanBlocked());
 
             return new FinanceProductResponse(
                     product.getFinProductId(),
@@ -156,11 +170,16 @@ public class FinanceService {
                     available ? loanOffer.appliedRate() : null,
                     available ? loanOffer.loanLimit() : null,
                     available,
+                    unavailableReason,
                     product.getDurationMonths(),
                     product.getMonthlyPaymentAmount(),
                     product.getDescription()
             );
         }
+
+        boolean alreadyJoined = activeSavingProductIds.contains(product.getFinProductId());
+        boolean lowScoreForEsgMaster = isEsgMasterSaving(product) && user.getTotalScore() < ESG_MASTER_MIN_TOTAL_SCORE;
+        boolean available = !alreadyJoined && !lowScoreForEsgMaster;
 
         return new FinanceProductResponse(
                 product.getFinProductId(),
@@ -171,7 +190,8 @@ public class FinanceService {
                 product.getMaxRate(),
                 product.getBaseRate(),
                 null,
-                true,
+                available,
+                determineSavingUnavailableReason(alreadyJoined, lowScoreForEsgMaster),
                 product.getDurationMonths(),
                 product.getMonthlyPaymentAmount(),
                 product.getDescription()
@@ -293,6 +313,34 @@ public class FinanceService {
             return ProductType.SAVINGS;
         }
         throw new BadRequestException("Invalid product type.");
+    }
+
+    private String determineLoanUnavailableReason(boolean scoreAvailable, boolean hasActiveLoan, boolean loanBlocked) {
+        if (loanBlocked) {
+            return REASON_LOAN_BLOCKED;
+        }
+        if (hasActiveLoan) {
+            return REASON_HAS_ACTIVE_LOAN;
+        }
+        if (!scoreAvailable) {
+            return REASON_LOW_SCORE;
+        }
+        return REASON_AVAILABLE;
+    }
+
+    private String determineSavingUnavailableReason(boolean alreadyJoined, boolean lowScoreForEsgMaster) {
+        if (alreadyJoined) {
+            return REASON_ALREADY_JOINED;
+        }
+        if (lowScoreForEsgMaster) {
+            return REASON_LOW_SCORE_FOR_ESG_MASTER;
+        }
+        return REASON_AVAILABLE;
+    }
+
+    private boolean isEsgMasterSaving(FinancialProduct product) {
+        String productName = product.getName();
+        return productName != null && productName.contains(ESG_MASTER_KEYWORD);
     }
 
     private User getUser(String loginId) {

--- a/src/main/java/com/shinhan/esg_be/domain/bank/service/SavingService.java
+++ b/src/main/java/com/shinhan/esg_be/domain/bank/service/SavingService.java
@@ -23,6 +23,8 @@ import java.time.LocalDate;
 public class SavingService {
 
     private static final long DEFAULT_MONTHLY_AMOUNT = 300_000L;
+    private static final String ESG_MASTER_KEYWORD = "ESG 마스터";
+    private static final int ESG_MASTER_MIN_TOTAL_SCORE = 900;
 
     private final UserRepository userRepository;
     private final FinancialProductRepository financialProductRepository;
@@ -42,6 +44,10 @@ public class SavingService {
             throw new BadRequestException("Already joined saving product.");
         }
 
+        if (isEsgMasterSaving(product) && user.getTotalScore() < ESG_MASTER_MIN_TOTAL_SCORE) {
+            throw new BadRequestException("ESG 마스터 적금은 900점 이상부터 가입할 수 있습니다.");
+        }
+
         Long monthlyAmount = product.getMonthlyPaymentAmount() != null
                 ? product.getMonthlyPaymentAmount()
                 : DEFAULT_MONTHLY_AMOUNT;
@@ -56,5 +62,10 @@ public class SavingService {
 
         userSavingRepository.save(userSaving);
         return new SavingApplyResponse(userSaving.getStatus().name());
+    }
+
+    private boolean isEsgMasterSaving(FinancialProduct product) {
+        String productName = product.getName();
+        return productName != null && productName.contains(ESG_MASTER_KEYWORD);
     }
 }

--- a/src/test/java/com/shinhan/esg_be/domain/bank/controller/FinanceControllerTest.java
+++ b/src/test/java/com/shinhan/esg_be/domain/bank/controller/FinanceControllerTest.java
@@ -185,6 +185,7 @@ class FinanceControllerTest {
                 new BigDecimal("7.00"),
                 2_000_000L,
                 true,
+                "AVAILABLE",
                 12,
                 null,
                 "description"
@@ -199,6 +200,7 @@ class FinanceControllerTest {
                 .andExpect(jsonPath("$.products[0].name").value("ESG Loan"))
                 .andExpect(jsonPath("$.products[0].subtitle").value("ESG based loan product"))
                 .andExpect(jsonPath("$.products[0].loanLimit").value(2000000))
-                .andExpect(jsonPath("$.products[0].appliedRate").value(7.00));
+                .andExpect(jsonPath("$.products[0].appliedRate").value(7.00))
+                .andExpect(jsonPath("$.products[0].unavailableReason").value("AVAILABLE"));
     }
 }

--- a/src/test/java/com/shinhan/esg_be/domain/bank/service/FinanceServiceTest.java
+++ b/src/test/java/com/shinhan/esg_be/domain/bank/service/FinanceServiceTest.java
@@ -197,6 +197,7 @@ class FinanceServiceTest {
         assertThat(response.products()).hasSize(1);
         assertThat(response.products().get(0).subtitle()).isEqualTo("ESG Loan subtitle");
         assertThat(response.products().get(0).available()).isTrue();
+        assertThat(response.products().get(0).unavailableReason()).isEqualTo("AVAILABLE");
         assertThat(response.products().get(0).loanLimit()).isEqualTo(2_000_000L);
         assertThat(response.products().get(0).appliedRate()).isEqualByComparingTo("7.00");
         assertThat(response.products().get(0).monthlyPaymentAmount()).isNull();
@@ -219,6 +220,7 @@ class FinanceServiceTest {
         assertThat(response.products()).hasSize(1);
         assertThat(response.products().get(0).subtitle()).isEqualTo("ESG Loan subtitle");
         assertThat(response.products().get(0).available()).isFalse();
+        assertThat(response.products().get(0).unavailableReason()).isEqualTo("HAS_ACTIVE_LOAN");
         assertThat(response.products().get(0).loanLimit()).isNull();
         assertThat(response.products().get(0).appliedRate()).isNull();
         assertThat(response.products().get(0).monthlyPaymentAmount()).isNull();
@@ -239,6 +241,7 @@ class FinanceServiceTest {
         assertThat(response.products()).hasSize(1);
         assertThat(response.products().get(0).subtitle()).isEqualTo("Green Saving subtitle");
         assertThat(response.products().get(0).available()).isTrue();
+        assertThat(response.products().get(0).unavailableReason()).isEqualTo("AVAILABLE");
         assertThat(response.products().get(0).baseRate()).isEqualByComparingTo("2.00");
         assertThat(response.products().get(0).maxRate()).isEqualByComparingTo("4.40");
         assertThat(response.products().get(0).appliedRate()).isEqualByComparingTo("2.00");
@@ -246,7 +249,7 @@ class FinanceServiceTest {
     }
 
     @Test
-    void getSavingProductsExcludesActiveSavingProduct() {
+    void getSavingProductsIncludesActiveSavingProductAsUnavailable() {
         User user = createUser("finance-user-4", 50, 250, 100, 100);
         ReflectionTestUtils.setField(user, "userId", 1L);
 
@@ -264,9 +267,35 @@ class FinanceServiceTest {
 
         FinanceProductListResponse response = financeService.getFinanceProducts(user.getLoginId(), "savings");
 
+        assertThat(response.products()).hasSize(2);
+        assertThat(response.products().get(0).id()).isEqualTo(10L);
+        assertThat(response.products().get(0).name()).isEqualTo("Joined Saving");
+        assertThat(response.products().get(0).available()).isFalse();
+        assertThat(response.products().get(0).unavailableReason()).isEqualTo("ALREADY_JOINED");
+        assertThat(response.products().get(1).id()).isEqualTo(20L);
+        assertThat(response.products().get(1).name()).isEqualTo("Available Saving");
+        assertThat(response.products().get(1).available()).isTrue();
+        assertThat(response.products().get(1).unavailableReason()).isEqualTo("AVAILABLE");
+    }
+
+    @Test
+    void getSavingProductsMarksEsgMasterUnavailableWhenScoreIsTooLow() {
+        User user = createUser("finance-user-master-low", 50, 250, 100, 100);
+        ReflectionTestUtils.setField(user, "userId", 1L);
+
+        FinancialProduct product = createFinancialProduct("ESG 마스터 적금", ProductType.SAVINGS, "4.00", "10.00", 12);
+        ReflectionTestUtils.setField(product, "finProductId", 30L);
+
+        given(userRepository.findByLoginId(user.getLoginId())).willReturn(Optional.of(user));
+        given(financialProductRepository.findByTypeAndIsActiveTrue(ProductType.SAVINGS)).willReturn(List.of(product));
+        given(userSavingRepository.findAllByUser_UserIdAndStatus(1L, SavingStatus.ACTIVE)).willReturn(List.of());
+
+        FinanceProductListResponse response = financeService.getFinanceProducts(user.getLoginId(), "savings");
+
         assertThat(response.products()).hasSize(1);
-        assertThat(response.products().get(0).id()).isEqualTo(20L);
-        assertThat(response.products().get(0).name()).isEqualTo("Available Saving");
+        assertThat(response.products().get(0).id()).isEqualTo(30L);
+        assertThat(response.products().get(0).available()).isFalse();
+        assertThat(response.products().get(0).unavailableReason()).isEqualTo("LOW_SCORE_FOR_ESG_MASTER");
     }
 
     @Test
@@ -290,6 +319,8 @@ class FinanceServiceTest {
         assertThat(response.products()).hasSize(1);
         assertThat(response.products().get(0).id()).isEqualTo(10L);
         assertThat(response.products().get(0).name()).isEqualTo("Completed Saving");
+        assertThat(response.products().get(0).available()).isTrue();
+        assertThat(response.products().get(0).unavailableReason()).isEqualTo("AVAILABLE");
     }
 
     @Test

--- a/src/test/java/com/shinhan/esg_be/domain/bank/service/SavingServiceTest.java
+++ b/src/test/java/com/shinhan/esg_be/domain/bank/service/SavingServiceTest.java
@@ -98,6 +98,21 @@ class SavingServiceTest {
                 .hasMessage("Already joined saving product.");
     }
 
+    @Test
+    @DisplayName("ESG 마스터 적금은 900점 미만이면 가입을 거절한다")
+    void rejectEsgMasterWhenScoreIsTooLow() {
+        User user = createUser("saving-user-master-low", 50, 250, 100, 100);
+        FinancialProduct product = createSavingProduct(5L, "ESG 마스터 적금", 300_000L, 12);
+
+        given(userRepository.findByLoginId(user.getLoginId())).willReturn(Optional.of(user));
+        given(financialProductRepository.findByFinProductIdAndTypeAndIsActiveTrue(5L, ProductType.SAVINGS))
+                .willReturn(Optional.of(product));
+
+        assertThatThrownBy(() -> savingService.applySaving(user.getLoginId(), new SavingApplyRequest(5L)))
+                .isInstanceOf(BadRequestException.class)
+                .hasMessage("ESG 마스터 적금은 900점 이상부터 가입할 수 있습니다.");
+    }
+
     private User createUser(String loginId, int eScore, int sScore, int gActivityScore, int gRepaymentScore) {
         User user = newInstance(User.class);
         ReflectionTestUtils.setField(user, "loginId", loginId);


### PR DESCRIPTION
## 📌 작업 내용
- 적금 목록에서 가입 중인 상품도 노출하고 보유 중 사유를 응답
- ESG 마스터 적금 900점 미만 가입 제한 추가
- 금융상품 목록 응답에 `unavailableReason` 필드 추가

## 🛠 변경 사항
- `GET /api/v1/finance/list` 응답에 `unavailableReason` 추가
- 가입 중인 적금 상품을 목록에서 제외하지 않고 `available=false`, `unavailableReason=ALREADY_JOINED`로 응답
- ESG 마스터 적금은 총점 900점 미만일 때 `available=false`, `unavailableReason=LOW_SCORE_FOR_ESG_MASTER`로 응답
- `POST /api/v1/finance/savings/apply`에서 ESG 마스터 적금 900점 미만 가입 요청 차단
- 대출 상품도 동일 필드에 `AVAILABLE`, `HAS_ACTIVE_LOAN`, `LOAN_BLOCKED`, `LOW_SCORE` 사유를 응답

## ✅ 테스트 결과
- [x] 로컬에서 정상 동작 확인
- [x] 빌드 에러 없음